### PR TITLE
[Views integration] Provide a JSON field type for complex data fields

### DIFF
--- a/cmrf_views/cmrf_views.module
+++ b/cmrf_views/cmrf_views.module
@@ -1,1 +1,26 @@
 <?php
+
+/**
+ * Implements hook_theme().
+ */
+function cmrf_views_theme($existing, $type, $theme, $path) {
+  return [
+    'cmrf_views_field_json_item' => [
+      'variables' => [
+        'field' => NULL,
+        'count' => 0,
+        'item' => [],
+        'item_list' =>NULL,
+      ],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+function cmrf_views_theme_suggestions_cmrf_views_field_json_item(array $variables) {
+  $suggestions = array();
+  $suggestions[] = 'cmrf_views_field_json_item__' . $variables['field']->table . '__' . $variables['field']->field;
+  return $suggestions;
+}

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -161,6 +161,12 @@ class CMRFViews {
           case 32: // Markup field.
             $views_fields[$field_name] = $this->getMarkupField($field_prop);
             break;
+          case 2: // String field
+            if ($field_prop['format'] == 'json') {
+              $views_fields[$field_name] = $this->getJSONField($field_prop);
+              break;
+            }
+            // No "break" statement for other string types falling through.
           default: // Fallback standard field.
             $views_fields[$field_name] = $this->getStandardField($field_prop);
             break;
@@ -320,6 +326,17 @@ class CMRFViews {
         $field['filter']['options'] = $prop['options'];
       }
     }
+
+    return $field;
+  }
+
+  /**
+   * Generates JSON field for views data.
+   *
+   * @param $prop
+   */
+  private function getJSONField($prop) {
+    $field['field']['id']    = 'cmrf_views_json';
 
     return $field;
   }

--- a/cmrf_views/src/Plugin/views/field/JSON.php
+++ b/cmrf_views/src/Plugin/views/field/JSON.php
@@ -1,0 +1,274 @@
+<?php
+
+
+namespace Drupal\cmrf_views\Plugin\views\field;
+
+
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\Plugin\views\field\MultiItemsFieldHandlerInterface;
+use Drupal\views\ResultRow;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Iplementation for JSON field plugin.
+ *
+ * @ingroup cmrf_views_field_handlers
+ *
+ * @ViewsField("cmrf_views_json")
+ */
+class JSON extends \Drupal\views\Plugin\views\field\Standard implements MultiItemsFieldHandlerInterface {
+
+  /**
+   * Does the field supports multiple field values.
+   *
+   * @var bool
+   */
+  public $multiple;
+
+  /**
+   * Does the rendered fields get limited.
+   *
+   * @var bool
+   */
+  public $limit_values;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
+
+    $this->multiple = FALSE;
+    $this->limit_values = FALSE;
+    $this->multiple = TRUE;
+
+    // If "First and last only" is chosen, limit the values
+    if (!empty($this->options['delta_first_last'])) {
+      $this->limit_values = TRUE;
+    }
+
+    // We only limit values if the user hasn't selected "all" or 0.
+    if ($this->options['delta_limit'] > 0 || intval($this->options['delta_offset'])) {
+      $this->limit_values = TRUE;
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function render_item($count, $item) {
+    // TODO: Provide a separate (overrideable) template?
+    $render = [
+      '#theme' => 'item_list',
+    ];
+    $i = 0;
+    foreach ($item as $attribute => $value) {
+      if (is_array($value)) {
+        $value = $this->render_item($i, $value);
+      }
+      $render['#items'][] = $value ;
+      $i++;
+    }
+    return render($render);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getItems(ResultRow $values) {
+    return \Drupal\Component\Serialization\Json::decode($values->{$this->field_alias});
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function renderItems($items) {
+    $items = $this->prepareItemsByDelta($items);
+    if (!empty($items)) {
+      if ($this->options['multi_type'] == 'separator') {
+        $separator = $this->options['multi_type'] == 'separator' ? Xss::filterAdmin($this->options['separator']) : '';
+        $build = [
+          '#type' => 'inline_template',
+          '#template' => '{{ items | safe_join(separator) }}',
+          '#context' => ['separator' => $separator, 'items' => $items],
+        ];
+      }
+      else {
+        $build = [
+          '#theme' => 'item_list',
+          '#items' => $items,
+          '#title' => NULL,
+          '#list_type' => $this->options['multi_type'],
+        ];
+      }
+      return $this->renderer->render($build);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function defineOptions() {
+    $options = parent::defineOptions();
+    // Options used for multiple value fields.
+    // Default to 'all'.
+    $options['delta_limit'] = [
+      'default' => 0,
+    ];
+    $options['delta_offset'] = [
+      'default' => 0,
+    ];
+    $options['delta_reversed'] = [
+      'default' => FALSE,
+    ];
+    $options['delta_first_last'] = [
+      'default' => FALSE,
+    ];
+
+    $options['multi_type'] = [
+      'default' => 'separator',
+    ];
+    $options['separator'] = [
+      'default' => ', ',
+    ];
+
+    return $options;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+
+    $this->multiple_options_form($form, $form_state);
+  }
+
+  /**
+   * Provide options for multiple value fields.
+   */
+  public function multiple_options_form(&$form, FormStateInterface $form_state) {
+    $form['multiple_field_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Multiple field settings'),
+      '#weight' => 5,
+    ];
+
+    // Make the string translatable by keeping it as a whole rather than
+    // translating prefix and suffix separately.
+    [$prefix, $suffix] = explode('@count', $this->t('Display @count value(s)'));
+
+    $form['multi_type'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Display type'),
+      '#options' => [
+        'ul' => $this->t('Unordered list'),
+        'ol' => $this->t('Ordered list'),
+        'separator' => $this->t('Simple separator'),
+      ],
+      '#default_value' => $this->options['multi_type'],
+      '#fieldset' => 'multiple_field_settings',
+    ];
+
+    $form['separator'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Separator'),
+      '#default_value' => $this->options['separator'],
+      '#states' => [
+        'visible' => [
+          ':input[name="options[multi_type]"]' => ['value' => 'separator'],
+        ],
+      ],
+      '#fieldset' => 'multiple_field_settings',
+    ];
+
+    $form['delta_limit'] = [
+      '#type' => 'textfield',
+      '#size' => 5,
+      '#field_prefix' => $prefix,
+      '#field_suffix' => $suffix,
+      '#default_value' => $this->options['delta_limit'],
+      '#prefix' => '<div class="container-inline">',
+      '#fieldset' => 'multiple_field_settings',
+    ];
+
+    [$prefix, $suffix] = explode('@count', $this->t('starting from @count'));
+    $form['delta_offset'] = [
+      '#type' => 'textfield',
+      '#size' => 5,
+      '#field_prefix' => $prefix,
+      '#field_suffix' => $suffix,
+      '#default_value' => $this->options['delta_offset'],
+      '#description' => $this->t('(first item is 0)'),
+      '#fieldset' => 'multiple_field_settings',
+    ];
+    $form['delta_reversed'] = [
+      '#title' => $this->t('Reversed'),
+      '#type' => 'checkbox',
+      '#default_value' => $this->options['delta_reversed'],
+      '#suffix' => $suffix,
+      '#description' => $this->t('(start from last values)'),
+      '#fieldset' => 'multiple_field_settings',
+    ];
+    $form['delta_first_last'] = [
+      '#title' => $this->t('First and last only'),
+      '#type' => 'checkbox',
+      '#default_value' => $this->options['delta_first_last'],
+      '#suffix' => '</div>',
+      '#fieldset' => 'multiple_field_settings',
+    ];
+  }
+
+  /**
+   * Adapts the $items according to the delta configuration.
+   *
+   * This selects displayed deltas, reorders items, and takes offsets into
+   * account.
+   *
+   * @param array $all_values
+   *   The items for individual rendering.
+   *
+   * @return array
+   *   The manipulated items.
+   */
+  protected function prepareItemsByDelta(array $all_values) {
+    if ($this->options['delta_reversed']) {
+      $all_values = array_reverse($all_values);
+    }
+
+    // We are supposed to show only certain deltas.
+    if ($this->limit_values) {
+      $delta_limit = $this->options['delta_limit'];
+      $offset = intval($this->options['delta_offset']);
+      if ($delta_limit == 0) {
+        $delta_limit = count($all_values) - $offset;
+      }
+
+      // Determine if only the first and last values should be shown.
+      $delta_first_last = $this->options['delta_first_last'];
+
+      $new_values = [];
+      for ($i = 0; $i < $delta_limit; $i++) {
+        $new_delta = $offset + $i;
+
+        if (isset($all_values[$new_delta])) {
+          // If first-last option was selected, only use the first and last
+          // values.
+          if (!$delta_first_last
+            // Use the first value.
+            || $new_delta == $offset
+            // Use the last value.
+            || $new_delta == ($delta_limit + $offset - 1)) {
+            $new_values[] = $all_values[$new_delta];
+          }
+        }
+      }
+      $all_values = $new_values;
+    }
+
+    return $all_values;
+  }
+
+}

--- a/cmrf_views/src/Plugin/views/field/JSON.php
+++ b/cmrf_views/src/Plugin/views/field/JSON.php
@@ -59,19 +59,29 @@ class JSON extends \Drupal\views\Plugin\views\field\Standard implements MultiIte
    * @inheritDoc
    */
   public function render_item($count, $item) {
-    // TODO: Provide a separate (overrideable) template?
+    $render = [
+      // Use a special overrideable template for each top-level JSON item.
+      '#theme' => 'cmrf_views_field_json_item',
+      '#field' => $this,
+      '#count' => $count,
+      '#item' => $item,
+      // Render an item list from the JSON structure as default markup.
+      '#item_list' => $this->render_item_item_list($item),
+    ];
+    return render($render);
+  }
+
+  public function render_item_item_list($item) {
     $render = [
       '#theme' => 'item_list',
     ];
-    $i = 0;
     foreach ($item as $attribute => $value) {
       if (is_array($value)) {
-        $value = $this->render_item($i, $value);
+        $value = $this->render_item_item_list($value);
       }
       $render['#items'][] = $value ;
-      $i++;
     }
-    return render($render);
+    return $render;
   }
 
   /**

--- a/cmrf_views/templates/cmrf-views-field-json-item.html.twig
+++ b/cmrf_views/templates/cmrf-views-field-json-item.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a CiviMRF Views JSON field item.
+ *
+ * Available variables:
+ * - item: The array structure of the current item.
+ * - count: The (zero-based) number of the current item.
+ * - field: The Drupal\cmrf_views\Plugin\views\field\JSON instance of the field
+ *   the current item belongs to.
+ * - item_list: A rendered item list of the array structure of the current item.
+ *
+ * @see template_preprocess_cmrf_views_field_json_item()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ item_list }}


### PR DESCRIPTION
This provides a new Views field handler for JSON structured data retrieved from a CiviCRM API within a CiviMRF Views Dataset.

The field definition retrieved by the `getfields` CiviCRM API call must be as follows:

```json
{
  "name": "the_field_name",
  "type": 2,
  "format": "json",
  "title": "The Field Label",
  "description": "This is the field description."
}
```
It must have the `T_STRING` (`2`) field type and an attribute `format` with the value `json`. The field itself, as retrieved by the `get` or `getsingle` CiviCRM API call, must be valid JSON, either an array or an object.

_An example scenario is a "pseudo" field on a custom CiviCRM API entity combining related data in a single field, so that no Views relationship is required. This might be an array of activities assigned to a CiviCRM contact, or participants of a CiviCRM event._

The field handler provides the ability to configure how to display the top-level items of the JSON structure in the Views UI, just like field handlers for Drupal fields with multiple items (cardinality > 1) do, i.e. either with a simple separator, or as an ordered or unordered list.

Each top-level item of the JSON structure is being rendered with a special template provided with this module. This, as a default, prints each item as an unordered list (`item_list`) with unlimited depth, but may be overridden in a theme or module for doing anything with each item _(e.g. printing only the activity's subject, or printing the participant's name and status_).

I will merge this PR once I think it's ready, but wanted to share it for discussion already.