### PR TITLE
Drupal 9 compatibility 

### DIFF
--- a/cmrf_call_report/src/Controller/CMRFCallreportController.php
+++ b/cmrf_call_report/src/Controller/CMRFCallreportController.php
@@ -39,7 +39,7 @@ class CMRFCallreportController extends ControllerBase {
     if($call) {
 
       $date = new \DateTime($call->create_date);
-      $date = format_date($date->getTimestamp());
+      $date = \Drupal::service('date.formatter')->format($date->getTimestamp());
       $status = $call->status;
       $profile = "";//$core->getConnectionProfile($call->connector_id);
       $request = nl2br(json_encode(json_decode($call->request, true), JSON_PRETTY_PRINT));
@@ -53,7 +53,7 @@ class CMRFCallreportController extends ControllerBase {
       $caching_until = '';
       if (!empty($call->cached_until)) {
         $caching_until = new \DateTime($call->cached_until);
-        $caching_until = format_date($caching_until->getTimestamp());
+        $caching_until = \Drupal::service('date.formatter')->format($caching_until->getTimestamp());
       }
       $retry_count = $call->retry_count;
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -11,7 +11,7 @@ class Core extends AbstractCore {
 
   public function __construct() {
     $db         = \Drupal::database()->getConnectionOptions();
-    $table_name = \Drupal::database()->prefixTables("{civicrm_api_call}");
+    $table_name = trim(\Drupal::database()->prefixTables("{civicrm_api_call}"), '"');
     $conn       = new \mysqli($db['host'], $db['username'], $db['password'], $db['database'], empty($db['port']) ? NULL : $db['port']);
     $factory    = new SQLPersistingCallFactory($conn, $table_name, ['\Drupal\cmrf_core\Call', 'createNew'], ['\Drupal\cmrf_core\Call', 'createWithRecord']);
     parent::__construct($factory);

--- a/src/Entity/CMRFConnector.php
+++ b/src/Entity/CMRFConnector.php
@@ -27,6 +27,12 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label" = "label",
  *     "uuid" = "uuid"
  *   },
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "type",
+ *     "profile"
+ *   },
  *   links = {
  *     "canonical" = "/admin/config/cmrf_connector/{cmrf_connector}",
  *     "add-form" = "/admin/config/cmrf_connector/add",

--- a/src/Entity/CMRFProfile.php
+++ b/src/Entity/CMRFProfile.php
@@ -27,6 +27,13 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label" = "label",
  *     "uuid" = "uuid"
  *   },
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "url",
+ *     "site_key",
+ *     "api_key"
+ *   },
  *   links = {
  *     "canonical" = "/admin/config/cmrf_profile/{cmrf_profile}",
  *     "add-form" = "/admin/config/cmrf_profile/add",


### PR DESCRIPTION
A number of changes to make cmrf_core compatible with Drupal 9. Its just enough to get cmrf_form_processor working:

* Drupal 9 makes the _config_export_ annotation mandatory. I made an educated guess of what this annotation should do and added some. I am not sure if the configuration can be exported now, but the entities work with Drupal 9.
* _format_date_ is deprecated. I replaced it with the Drupal 9 equivalent.
* _\Drupal::database()->prefixTables("{civicrm_api_call}")_ adds quotes in Drupal 9. This free service breaks the database insert in of the call logging service. So I removed them. 