### PR TITLE
Made autoload conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 CMRF is a CiviCRM remote integration toolkit. This repository is a **Drupal module** wrapping the core.
 
 # Install
-Use composer to install the abstract core library:
 
- 1. ``> cd cmrf_core``
- 1. ``composer install``
+You have two methods to install this module. Both need composer.
+
+## Download installation method
+
+1. Download and untar this module in the `<drupdalroot>/web/modules/contrib` directory.
+1. ``> cd cmrf_core``
+1. ``composer install``
+
+## Composer only method
+1. Add this repository to the composer configuration with
+`composer config repositories.cmrf_core vcs https://github.com/CiviMRF/cmrf_core.git`
+1. Now use composer for the install `composer require drupal/cmrf_core`.
 
 # Setup
 

--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -1,5 +1,7 @@
 <?php
-require_once dirname(__FILE__).'/vendor/autoload.php';
+if (!class_exists('\CMRF\PersistenceLayer\SQLPersistingCallFactory')) {
+  require_once dirname(__FILE__) . '/vendor/autoload.php';
+}
 
 function cmrf_core_schema() {
   $array=array();

--- a/cmrf_core.module
+++ b/cmrf_core.module
@@ -1,6 +1,7 @@
 <?php
-
-require_once dirname(__FILE__) . '/vendor/autoload.php';
+if (!class_exists('\CMRF\PersistenceLayer\SQLPersistingCallFactory')) {
+  require_once dirname(__FILE__) . '/vendor/autoload.php';
+}
 
 /**
  * @file


### PR DESCRIPTION
The current installation method creates a separate vendor directory inside the module directory. De library code is loaded with an autoload file in the `.module` file and the `.install`. Now an alternative method is offered where the dependent libraries are installed in the central drupal vendor library. This is described in the README. The autoload is made conditional, its not called if the CMFR libraries are already loaded.