### PR TITLE
Added purge civicrm_api_calls to the cron

### DIFF
--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -1,10 +1,13 @@
 <?php
+
+use Drupal\cmrf_core\CallFactory;
+
 if (!class_exists('\CMRF\PersistenceLayer\SQLPersistingCallFactory')) {
   require_once dirname(__FILE__) . '/vendor/autoload.php';
 }
 
 function cmrf_core_schema() {
   $array=array();
-  $array['civicrm_api_call']=\CMRF\PersistenceLayer\SQLPersistingCallFactory::schema();
+  $array['civicrm_api_call'] = CallFactory::schema();
   return $array;
 }

--- a/cmrf_core.module
+++ b/cmrf_core.module
@@ -16,3 +16,9 @@ function cmrf_core_cache_flush() {
   $core = Drupal::service('cmrf_core.core');
   $core->getFactory()->purgeCachedCalls();
 }
+
+function cmrf_core_cron() {
+  /** @var \Drupal\cmrf_core\Core $core */
+  $core = Drupal::service('cmrf_core.core');
+  $core->getFactory()->purgeCachedCalls();
+}

--- a/src/CallFactory.php
+++ b/src/CallFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Drupal\cmrf_core;
+
+use CMRF\PersistenceLayer\SQLPersistingCallFactory;
+
+class CallFactory extends SQLPersistingCallFactory {
+
+  /**
+   * @var \Drupal\cmrf_core\Core;
+   */
+  private $core;
+  protected $table_name;
+
+  public function __construct($sql_connection, $table_name, $constructor, $loader) {
+    parent::__construct($sql_connection, $table_name,$constructor,$loader);
+  }
+
+  public function purgeCachedCalls() {
+    parent::purgeCachedCalls();
+    foreach($this->core->getConnectors() as $connector){
+      $profile = $this->core->getConnectionProfile($connector);
+      if ($profile['cache_expire_days'] > 0) {
+        $today = new \DateTime();
+        $today->modify('-'.$profile['cache_expire_days'].' days');
+        $sql = "delete from {$this->table_name} where DATE(`create_date`) < '".$today->format('Y-m-d')."' AND `connector_id` = '".$connector."'";
+        \Drupal::database()->query($sql);
+      }
+    }
+  }
+
+  /**
+   * @return \Drupal\cmrf_core\Core
+   */
+  public function getCore(): Core {
+    return $this->core;
+  }
+
+  /**
+   * @param \Drupal\cmrf_core\Core $core
+   */
+  public function setCore(Core $core): void {
+    $this->core = $core;
+  }
+
+}

--- a/src/Core.php
+++ b/src/Core.php
@@ -1,7 +1,6 @@
 <?php namespace Drupal\cmrf_core;
 
 use CMRF\Core\Core as AbstractCore;
-use CMRF\PersistenceLayer\SQLPersistingCallFactory;
 use Drupal\cmrf_core\Entity\CMRFConnector;
 use Drupal\cmrf_core\Entity\CMRFProfile;
 
@@ -13,7 +12,8 @@ class Core extends AbstractCore {
     $db         = \Drupal::database()->getConnectionOptions();
     $table_name = trim(\Drupal::database()->prefixTables("{civicrm_api_call}"), '"');
     $conn       = new \mysqli($db['host'], $db['username'], $db['password'], $db['database'], empty($db['port']) ? NULL : $db['port']);
-    $factory    = new SQLPersistingCallFactory($conn, $table_name, ['\Drupal\cmrf_core\Call', 'createNew'], ['\Drupal\cmrf_core\Call', 'createWithRecord']);
+    $factory    = new CallFactory($conn, $table_name, ['\Drupal\cmrf_core\Call', 'createNew'], ['\Drupal\cmrf_core\Call', 'createWithRecord']);
+    $factory->setCore($this);
     parent::__construct($factory);
   }
 
@@ -46,6 +46,7 @@ class Core extends AbstractCore {
         'url'      => $entity->url,
         'api_key'  => $entity->api_key,
         'site_key' => $entity->site_key,
+        'cache_expire_days' => $entity->cache_expire_days,
       ];
     }
     return $return;

--- a/src/Entity/CMRFProfile.php
+++ b/src/Entity/CMRFProfile.php
@@ -32,7 +32,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label",
  *     "url",
  *     "site_key",
- *     "api_key"
+ *     "api_key",
+ *     "cache_expire_days",
  *   },
  *   links = {
  *     "canonical" = "/admin/config/cmrf_profile/{cmrf_profile}",
@@ -81,5 +82,12 @@ class CMRFProfile extends ConfigEntityBase implements CMRFProfileInterface {
    * @var string
    */
   public $api_key;
+  /**
+   * The time that the messages in the call log are stored before they are
+   * deleted.
+   *
+   * @var string
+   */
+  public $cache_expire_days;
 
 }

--- a/src/Form/CMRFProfileForm.php
+++ b/src/Form/CMRFProfileForm.php
@@ -3,7 +3,6 @@
 use Drupal\cmrf_core\Entity\CMRFProfile;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\Messenger;
 
 /**
  * Class CMRFProfileForm.
@@ -60,6 +59,14 @@ class CMRFProfileForm extends EntityForm {
       '#default_value' => $cmrf_profile->api_key,
       '#maxlength'     => 255,
       '#description'   => $this->t('The api key of your civicrm installation.'),
+      '#required'      => TRUE,
+    ];
+
+    $form['cache_expire_days'] = [
+      '#type'          => 'textfield',
+      '#title'         => $this->t('Cache Expire'),
+      '#default_value' => $cmrf_profile->cache_expire_days ?? 0,
+      '#description'   => $this->t('Days that must be passed after wich the call log is purged.'),
       '#required'      => TRUE,
     ];
 


### PR DESCRIPTION
- added the call to the standard purge of all the 'DONE' calls to the cron.
- added the property `cache_expire_days' to the connector entity.
- added purge SQL to the corn job to purge all other calls after the asked number of days.

And

- created a subclass of the callfactory to add drupal8/9 specific code. (The drupal 7 version made a complete copy of the class, maye thats a better idea, but lets first try this).