### PR TITLE
Support CiviCRM APIv4

### DIFF
--- a/cmrf_call_report/cmrf_call_report.views.inc
+++ b/cmrf_call_report/cmrf_call_report.views.inc
@@ -67,6 +67,38 @@ function cmrf_call_report_views_data() {
       'id' => 'standard',
     ],
   ];
+  $data['civicrm_api_call']['entity'] = [
+    'title' => t('Entity'),
+    'help' => t('the CiviCRM API entity.'),
+    'field' => [
+      'id' => 'standard',
+    ],
+    'argument' => [
+      'id' => 'string',
+    ],
+    'filter' => [
+      'id' => 'string',
+    ],
+    'sort' => [
+      'id' => 'standard',
+    ],
+  ];
+  $data['civicrm_api_call']['action'] = [
+    'title' => t('Action'),
+    'help' => t('The CiviCRM API action.'),
+    'field' => [
+      'id' => 'standard',
+    ],
+    'argument' => [
+      'id' => 'string',
+    ],
+    'filter' => [
+      'id' => 'string',
+    ],
+    'sort' => [
+      'id' => 'standard',
+    ],
+  ];
   $data['civicrm_api_call']['request'] = [
     'title' => t('Request'),
     'help' => t('Request'),

--- a/cmrf_call_report/config/optional/views.view.cmrf_calls.yml
+++ b/cmrf_call_report/config/optional/views.view.cmrf_calls.yml
@@ -80,6 +80,8 @@ display:
             create_date: create_date
             status: status
             connector_id: connector_id
+            entity: entity
+            action: action
             request: request
             reply: reply
             scheduled_date: scheduled_date
@@ -113,6 +115,20 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            entity:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            action:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             request:
               sortable: false
               default_sort_order: asc
@@ -128,14 +144,14 @@ display:
               empty_column: false
               responsive: ''
             scheduled_date:
-              sortable: false
+              sortable: true
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
             retry_count:
-              sortable: false
+              sortable: true
               default_sort_order: asc
               align: ''
               separator: ''
@@ -352,6 +368,104 @@ display:
           empty_zero: false
           hide_alter_empty: true
           plugin_id: standard
+        entity:
+          id: entity
+          table: civicrm_api_call
+          field: entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          label: Entity
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: pre
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        action:
+          id: action
+          table: civicrm_api_call
+          field: action
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          label: Aktion
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: pre
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
         request:
           id: request
           table: civicrm_api_call
@@ -388,7 +502,7 @@ display:
             trim: true
             preserve_tags: ''
             html: false
-          element_type: ''
+          element_type: pre
           element_class: ''
           element_label_type: ''
           element_label_class: ''
@@ -437,7 +551,7 @@ display:
             trim: true
             preserve_tags: ''
             html: false
-          element_type: ''
+          element_type: pre
           element_class: ''
           element_label_type: ''
           element_label_class: ''

--- a/cmrf_call_report/src/Controller/CMRFCallreportController.php
+++ b/cmrf_call_report/src/Controller/CMRFCallreportController.php
@@ -52,7 +52,10 @@ class CMRFCallreportController extends ControllerBase {
       $date = \Drupal::service('date.formatter')->format($date->getTimestamp());
       $status = $call->status;
       $profile = $this->core->getConnectionProfile($call->connector_id);
-      $request = json_encode(json_decode($call->request, true), JSON_PRETTY_PRINT);
+      $request = json_decode($call->request, true);
+      $entity = $call->entity ?? $request['entity'] ?? NULL;
+      $action = $call->action ?? $request['action'] ?? NULL;
+      $request = json_encode($request, JSON_PRETTY_PRINT);
       $reply = json_encode(json_decode($call->reply,true), JSON_PRETTY_PRINT);
       $metadata = json_encode(json_decode($call->metadata,true), JSON_PRETTY_PRINT);
       $scheduled_date = '';
@@ -84,6 +87,14 @@ class CMRFCallreportController extends ControllerBase {
         [
           ['data' => t('Profile'), 'header' => TRUE],
           ['data' => $profile['label']],
+        ],
+        [
+          ['data' => t('Entity'), 'header' => TRUE],
+          ['data' => ['#markup' => '<pre>' . $entity . '</pre>']],
+        ],
+        [
+          ['data' => t('Action'), 'header' => TRUE],
+          ['data' => ['#markup' => '<pre>' . $action . '</pre>']],
         ],
         [
           ['data' => t('Request'), 'header' => TRUE],

--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -11,3 +11,26 @@ function cmrf_core_schema() {
   $array['civicrm_api_call'] = CallFactory::schema();
   return $array;
 }
+
+/**
+ * Add columns "entity" and "action" to the "civicrm_api_call" database table.
+ */
+function cmrf_core_update_8201(&$sandbox) {
+  $entity_field = array(
+    'description' => 'The CiviCRM API entity',
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => TRUE,
+    'default' => '',
+  );
+  \Drupal::database()->schema()->addField('civicrm_api_call', 'entity', $entity_field);
+
+  $action_field = array(
+    'description' => 'The CiviCRM API action',
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => TRUE,
+    'default' => '',
+  );
+  \Drupal::database()->schema()->addField('civicrm_api_call', 'action', $action_field);
+}

--- a/cmrf_views/cmrf_views.install
+++ b/cmrf_views/cmrf_views.install
@@ -15,3 +15,17 @@ function cmrf_views_update_8001(&$sandbox) {
       return TRUE;
   });
 }
+
+/**
+ * Add new configuration option "API version" for Views Datasets.
+ */
+function cmrf_views_update_8002(&$sandbox) {
+  // Update the configuration entity type "cmrf_dataset".
+  \Drupal::classResolver(ConfigEntityUpdater::class)
+    ->update($sandbox, 'cmrf_dataset', function ($entity) {
+      // Set default value for all existing datasets.
+      $entity->set('api_version', 3);
+      // Return TRUE for saving the entity.
+      return TRUE;
+  });
+}

--- a/cmrf_views/config/schema/cmrf_views.schema.yml
+++ b/cmrf_views/config/schema/cmrf_views.schema.yml
@@ -28,6 +28,9 @@ cmrf_views.cmrf_dataset.*:
     params:
       type: string
       label: 'API Parameters'
+    api_version:
+      type: integer
+      label: 'API version'
     relationships:
       type: sequence
       label: 'Relationships'

--- a/cmrf_views/src/CMRFDatasetListBuilder.php
+++ b/cmrf_views/src/CMRFDatasetListBuilder.php
@@ -20,6 +20,7 @@ class CMRFDatasetListBuilder extends ConfigEntityListBuilder {
     $header['connector'] = $this->t('Connector');
     $header['entity'] = $this->t('Entity');
     $header['action'] = $this->t('Action');
+    $header['api_version'] = $this->t('API version');
     return $header + parent::buildHeader();
   }
 
@@ -33,6 +34,7 @@ class CMRFDatasetListBuilder extends ConfigEntityListBuilder {
     $row['connector'] = $entity->connector;
     $row['entity'] = $entity->entity;
     $row['action'] = $entity->action;
+    $row['api_version'] = $entity->api_version;
     return $row + parent::buildRow($entity);
   }
 

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -161,6 +161,7 @@ class CMRFViews {
       foreach ($fields['values'] as $field_name => $field_prop) {
         $original_field_name = $field_name;
         $field_name = str_replace('.', '__', $field_name);
+        $field_prop['api.version'] = $apiVersion;
 
         // If we don't have a field type, set it to 0.
         if ($apiVersion == 3 && !isset($field_prop['type'])) {
@@ -301,7 +302,10 @@ class CMRFViews {
     }
 
     // If 'type' is 1024 (Money).
-    if ((!empty($prop['data_type'])) && ($prop['type'] == 1024)) {
+    if (
+      ($prop['api.version'] == 3 && !empty($prop['data_type']) && ($prop['type'] == 1024))
+      || ($prop['api.version'] == 4 && ($prop['data_type'] == 'Money' || $prop['data_type'] == 'Float'))
+    ) {
       $field['field']['float'] = TRUE;
     }
 
@@ -312,11 +316,20 @@ class CMRFViews {
         $field['filter']['id'] = 'cmrf_views_filter_optionlist';
         $field['filter']['options'] = $prop['options'];
       } else {
-        $field['filter']['id'] = ($prop['type'] == 1024) ? 'cmrf_views_filter_text' : 'cmrf_views_filter_numeric';
+        if (
+          ($prop['api.version'] == 3 && $prop['type'] == 1024)
+          || ($prop['api.version'] == 4 && ($prop['data_type'] == 'Money' || $prop['data_type'] == 'Float'))
+        ) {
+          $field['filter']['id'] = 'cmrf_views_filter_text';
+        }
+        else {
+          $field['filter']['id'] = 'cmrf_views_filter_numeric';
+        }
       }
     }
 
     // If 'data_type' is file.
+    // TODO: Adapt for APIv4
     if ((!empty($prop['data_type'])) && ($prop['data_type'] == 'File')) {
       $field['field']['id'] = 'cmrf_views_file';
     }
@@ -458,6 +471,7 @@ class CMRFViews {
     }
 
     // If 'data_type' is file.
+    // TODO: Adapt for APIv4
     if ((!empty($prop['data_type'])) && ($prop['data_type'] == 'File')) {
       $field['field']['id'] = 'cmrf_views_file';
     }

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -231,6 +231,7 @@ class CMRFViews {
                 $views_fields[$field_name] = $this->getJSONField($field_prop);
                 break;
               }
+            // TODO: case 'Array'?
             // No "break" statement for other string types falling through.
             default: // Fallback standard field.
               $views_fields[$field_name] = $this->getStandardField($field_prop);

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -121,7 +121,7 @@ class CMRFViews {
         $dataset['connector'],
         $dataset['entity'],
         $dataset['getfields'],
-        ['api_action' => $dataset['action']] + $dataset['params'],
+        [($dataset['api_version'] == 4 ? 'action' : 'api_action') => $dataset['action']] + $dataset['params'],
         ['limit' => 0],
         NULL,
         $dataset['api_version']

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -328,9 +328,11 @@ class CMRFViews {
       }
     }
 
-    // If 'data_type' is file.
-    // TODO: Adapt for APIv4
-    if ((!empty($prop['data_type'])) && ($prop['data_type'] == 'File')) {
+    // If 'input_type' is file.
+    if (
+      ($prop['api.version'] == 3 && !empty($prop['data_type']) && $prop['data_type'] == 'File')
+      || ($prop['api.version'] == 4 && !empty($prop['input_type']) && $prop['input_type'] == 'File')
+    ) {
       $field['field']['id'] = 'cmrf_views_file';
     }
 
@@ -421,6 +423,14 @@ class CMRFViews {
       }
     }
 
+    // If 'input_type' is file.
+    if (
+      ($prop['api.version'] == 3 && !empty($prop['data_type']) && $prop['data_type'] == 'File')
+      || ($prop['api.version'] == 4 && !empty($prop['input_type']) && $prop['input_type'] == 'File')
+    ) {
+      $field['field']['id'] = 'cmrf_views_file';
+    }
+
     return $field;
   }
 
@@ -470,9 +480,11 @@ class CMRFViews {
       }
     }
 
-    // If 'data_type' is file.
-    // TODO: Adapt for APIv4
-    if ((!empty($prop['data_type'])) && ($prop['data_type'] == 'File')) {
+    // If 'input_type' is file.
+    if (
+      ($prop['api.version'] == 3 && !empty($prop['data_type']) && $prop['data_type'] == 'File')
+      || ($prop['api.version'] == 4 && !empty($prop['input_type']) && $prop['input_type'] == 'File')
+    ) {
       $field['field']['id'] = 'cmrf_views_file';
     }
 

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -136,6 +136,11 @@ class CMRFViews {
       if (empty($fields['values'])) {
         return [];
       }
+      $apiVersion = $call->getApiVersion();
+
+      if ($apiVersion == 4) {
+        $fields['values'] = array_combine(array_column($fields['values'], 'name'), $fields['values']);
+      }
 
       // Retrieve available relationships available for the current dataset.
       $dataset_relationships = CMRFDatasetRelationship::loadByDataset($dataset['id']);
@@ -147,8 +152,11 @@ class CMRFViews {
         $field_name = str_replace('.', '__', $field_name);
 
         // If we don't have a field type, set it to 0.
-        if (!isset($field_prop['type'])) {
+        if ($apiVersion == 3 && !isset($field_prop['type'])) {
           $field_prop['type'] = 0;
+        }
+        if ($apiVersion == 4 && !isset($field_prop['data_type'])) {
+          $field_prop['data_type'] = NULL;
         }
 
         // Set default for "api.filter".
@@ -161,31 +169,61 @@ class CMRFViews {
         }
 
         // Set field handler, filter, sort, etc.
-        switch ($field_prop['type']) {
-          case 1: // Integer field.
-          case 1024: // Money field.
-            $views_fields[$field_name] = $this->getNumericField($field_prop);
-            break;
-          case 4: // Date field.
-          case 12: // Date and time field.
-          case 256: // Timestamp field.
-            $views_fields[$field_name] = $this->getDateField($field_prop);
-            break;
-          case 16: // Boolean field.
-            $views_fields[$field_name] = $this->getBooleanField($field_prop);
-            break;
-          case 32: // Markup field.
-            $views_fields[$field_name] = $this->getMarkupField($field_prop);
-            break;
-          case 2: // String field
-            if (!empty($field_prop['format']) && $field_prop['format'] == 'json') {
-              $views_fields[$field_name] = $this->getJSONField($field_prop);
+        if ($apiVersion == 3) {
+          switch ($field_prop['type']) {
+            case 1: // Integer field.
+            case 1024: // Money field.
+              $views_fields[$field_name] = $this->getNumericField($field_prop);
               break;
-            }
+            case 4: // Date field.
+            case 12: // Date and time field.
+            case 256: // Timestamp field.
+              $views_fields[$field_name] = $this->getDateField($field_prop);
+              break;
+            case 16: // Boolean field.
+              $views_fields[$field_name] = $this->getBooleanField($field_prop);
+              break;
+            case 32: // Markup field.
+              $views_fields[$field_name] = $this->getMarkupField($field_prop);
+              break;
+            case 2: // String field
+              if (!empty($field_prop['format']) && $field_prop['format'] == 'json') {
+                $views_fields[$field_name] = $this->getJSONField($field_prop);
+                break;
+              }
             // No "break" statement for other string types falling through.
-          default: // Fallback standard field.
-            $views_fields[$field_name] = $this->getStandardField($field_prop);
-            break;
+            default: // Fallback standard field.
+              $views_fields[$field_name] = $this->getStandardField($field_prop);
+              break;
+          }
+        }
+        elseif ($apiVersion == 4) {
+          switch ($field_prop['data_type']) {
+            case 'Int':
+            case 'Integer':
+            case 'Money':
+              $views_fields[$field_name] = $this->getNumericField($field_prop);
+              break;
+            case 'Date':
+            case 'Timestamp':
+              $views_fields[$field_name] = $this->getDateField($field_prop);
+              break;
+            case 'Boolean':
+              $views_fields[$field_name] = $this->getBooleanField($field_prop);
+              break;
+            case 'Text':
+              $views_fields[$field_name] = $this->getMarkupField($field_prop);
+              break;
+            case 'String':
+              if (!empty($field_prop['format']) && $field_prop['format'] == 'json') {
+                $views_fields[$field_name] = $this->getJSONField($field_prop);
+                break;
+              }
+            // No "break" statement for other string types falling through.
+            default: // Fallback standard field.
+              $views_fields[$field_name] = $this->getStandardField($field_prop);
+              break;
+          }
         }
 
         // Set field basic information.

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -117,11 +117,22 @@ class CMRFViews {
       }
 
       // API Call to retrieve the fields.
+      if ($dataset['api_version'] == 4) {
+        $parameters = [
+          'action' => $dataset['action'],
+          'loadOptions' => TRUE,
+        ];
+      }
+      else {
+        $parameters = [
+          'api_action' => $dataset['action'],
+        ];
+      }
       $call = $this->core->createCall(
         $dataset['connector'],
         $dataset['entity'],
         $dataset['getfields'],
-        [($dataset['api_version'] == 4 ? 'action' : 'api_action') => $dataset['action']] + $dataset['params'],
+        $parameters + $dataset['params'],
         ['limit' => 0],
         NULL,
         $dataset['api_version']

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -92,6 +92,10 @@ class CMRFViews {
       $base_data['table']['base']['params'] = $dataset['params'];
     }
 
+    if (!empty($dataset['api_version'])) {
+      $base_data['table']['base']['api_version'] = $dataset['api_version'];
+    }
+
     return $base_data;
   }
 
@@ -118,7 +122,9 @@ class CMRFViews {
         $dataset['entity'],
         $dataset['getfields'],
         ['api_action' => $dataset['action']] + $dataset['params'],
-        ['limit' => 0]
+        ['limit' => 0],
+        NULL,
+        $dataset['api_version']
       );
       $this->core->executeCall($call);
       if ($call->getStatus() != Call::STATUS_DONE) {
@@ -417,6 +423,8 @@ class CMRFViews {
    * @param $field_name
    *
    * @return array
+   *
+   * TODO: Method does not seem to be called from anywhere. Deprecate or remove?
    */
   private function fetchOptions($connector, $api_entity, $api_action, $field_name) {
 
@@ -427,6 +435,7 @@ class CMRFViews {
       'getoptions',
       ['field' => $field_name],
       ['limit' => 0, 'cache' => '5 minutes']
+      // TODO: API version from Dataset configuration.
     );
 
     // Execute call.
@@ -446,6 +455,7 @@ class CMRFViews {
       'getfields', // TODO: Use "getfields" property of the Dataset?
       ['api_action' => $api_action],
       ['limit' => 0]
+      // TODO: API version from Dataset configuration.
     );
 
     // Execute call.

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -68,7 +68,7 @@ class CMRFViews {
       $base_data['table']['base']  = [
         'title'    => $dataset['label'],
         'help'     => $dataset['label'] . ' provided by CiviCRM API',
-        'query_id' => 'civicrm_api',
+        'query_id' => $dataset['api_version'] == 4 ? 'civicrm_api4' : 'civicrm_api',
       ];
     }
 

--- a/cmrf_views/src/CMRFViews.php
+++ b/cmrf_views/src/CMRFViews.php
@@ -212,6 +212,7 @@ class CMRFViews {
           switch ($field_prop['data_type']) {
             case 'Int':
             case 'Integer':
+            case 'Float':
             case 'Money':
               $views_fields[$field_name] = $this->getNumericField($field_prop);
               break;

--- a/cmrf_views/src/Entity/CMRFDataset.php
+++ b/cmrf_views/src/Entity/CMRFDataset.php
@@ -32,7 +32,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "action" = "action",
  *     "getcount" = "getcount",
  *     "getfields" = "getfields",
- *     "params" = "params"
+ *     "params" = "params",
+ *     "api_version" = "api_version"
  *   },
  *   links = {
  *     "canonical" = "/admin/config/cmrf/cmrf_views/datasets/manage/{cmrf_dataset}",
@@ -50,7 +51,8 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "action" = "action",
  *     "getcount" = "getcount",
  *     "getfields" = "getfields",
- *     "params" = "params"
+ *     "params" = "params",
+ *     "api_version" = "api_version"
  *   }
  * )
  */

--- a/cmrf_views/src/Form/CMRFDatasetForm.php
+++ b/cmrf_views/src/Form/CMRFDatasetForm.php
@@ -98,6 +98,15 @@ class CMRFDatasetForm extends EntityForm {
       '#required'      => FALSE,
     ];
 
+    $form['api_version'] = [
+      '#type'          => 'select',
+      '#title'         => t('API version'),
+      '#description'   => t('The API version the call should be made with.'),
+      '#options'       => [3 => '3', 4 => '4'],
+      '#default_value' => empty($entity->api_version) ? NULL : $entity->api_version,
+      '#required'      => TRUE,
+    ];
+
     // Provide a token browser.
     if (\Drupal::moduleHandler()->moduleExists('token')) {
       $form['token_tree'] = [

--- a/cmrf_views/src/Plugin/views/field/File.php
+++ b/cmrf_views/src/Plugin/views/field/File.php
@@ -172,21 +172,30 @@ class File extends FieldPluginBase {
           $this->core->executeCall($file);
           // Get reply.
           $attachment = $file->getReply();
-          // If we get an error, render fallback image.
-          if (!empty($attachment['is_error'])) {
-            return $this->renderFallbackImage();
+        }
+      }
+      elseif (is_string($value)) {
+        // The $value contains the URL.
+        $attachment = [
+          'url' => $value,
+          'id' => md5($value),
+          'name' => basename($value),
+        ];
+      }
+
+      // If we get an error, render fallback image.
+      if (!empty($attachment['is_error'])) {
+        return $this->renderFallbackImage();
+      }
+      // Check if we have necessary information to generate a link or save/show the file
+      if ((!empty($attachment['url'])) && (!empty($attachment['name']))) {
+        if (!empty($this->options['behaviour'])) {
+          // Save and show image.
+          if ($this->options['behaviour'] == 'image') {
+            return $this->getImage($attachment);
           }
-          // Check if we have necessary information to generate a link or save/show the file
-          if ((!empty($attachment['url'])) && (!empty($attachment['mime_type'])) && (!empty($attachment['name']))) {
-            if (!empty($this->options['behaviour'])) {
-              // Save and show image.
-              if ($this->options['behaviour'] == 'image') {
-                return $this->getImage($attachment);
-              }
-              // Show download link.
-              return $this->getDownloadLink($attachment);
-            }
-          }
+          // Show download link.
+          return $this->getDownloadLink($attachment);
         }
       }
     }
@@ -239,6 +248,9 @@ class File extends FieldPluginBase {
             }
             return $image_render;
           }
+          else {
+            return $this->renderFallbackImage();
+          }
         }
       }
     }
@@ -246,7 +258,7 @@ class File extends FieldPluginBase {
   }
 
   private function getDownloadLink($attachment = NULL) {
-    if ((!empty($attachment['url'])) && (!empty($attachment['mime_type'])) && (!empty($attachment['name']))) {
+    if ((!empty($attachment['url'])) && (!empty($attachment['name']))) {
       // Get drupal query string.
       $query_string = \Drupal::request()->query->all();
       // Generate salt and hash.
@@ -256,7 +268,9 @@ class File extends FieldPluginBase {
       if ((isset($query_string['civi_file_hash'])) && ($query_string['civi_file_hash'] == $hash)) {
         header('Content-Description: File Transfer');
         //header('Content-Type: application/octet-stream');
-        header('Content-Type: ' . $attachment['mime_type']);
+        if (!empty($attachment['mime_type'])) {
+          header('Content-Type: ' . $attachment['mime_type']);
+        }
         header('Content-Disposition: attachment; filename="' . $attachment['name'] . '"');
         header('Expires: 0');
         header('Cache-Control: must-revalidate');

--- a/cmrf_views/src/Plugin/views/query/API.php
+++ b/cmrf_views/src/Plugin/views/query/API.php
@@ -1,4 +1,6 @@
-<?php namespace Drupal\cmrf_views\Plugin\views\query;
+<?php
+
+namespace Drupal\cmrf_views\Plugin\views\query;
 
 use Drupal;
 use Drupal\cmrf_core\Call;
@@ -256,11 +258,6 @@ class API extends QueryPluginBase {
       // View result init.
       $view->result = [];
 
-      $field_id_alias_mapping = array_combine(
-        array_keys($view->field),
-        array_column($view->field, 'field_alias')
-      );
-
       // Data API call.
       $call = $this->core->createCall($connector, $api_entity, $api_action, $parameters, $options, NULL, $api_version);
       $this->core->executeCall($call);
@@ -291,7 +288,7 @@ class API extends QueryPluginBase {
       foreach ($view->relationship as $field_name => $relationship) {
         $field_name = self::getFieldAlias($view->storage->get('base_table'), $field_name);
         $referenced_keys = [];
-        foreach ($view->result as $row_key => &$row) {
+        foreach ($view->result as $row) {
           if (isset($row->{$field_name})) {
             $referenced_keys[] = $row->{$field_name};
           }
@@ -335,7 +332,7 @@ class API extends QueryPluginBase {
                   }
                 }
                 // Add values to corresponding base rows.
-                foreach ($view->result as $row_key => &$row) {
+                foreach ($view->result as &$row) {
                   if (
                     isset($row->{$field_name})
                     && $row->{$field_name} == $relationship_result[$base_field_alias]

--- a/cmrf_views/src/Plugin/views/query/API.php
+++ b/cmrf_views/src/Plugin/views/query/API.php
@@ -157,6 +157,7 @@ class API extends QueryPluginBase {
     if (!empty($table_data)) {
       $api_entity       = $table_data['table']['base']['entity'];
       $api_action       = $table_data['table']['base']['action'];
+      $api_version      = $table_data['table']['base']['api_version'];
       $api_count_action = $table_data['table']['base']['getcount'];
       $connector        = $table_data['table']['base']['connector'];
       $dataset_params   = $table_data['table']['base']['params'] ?? [];
@@ -235,7 +236,7 @@ class API extends QueryPluginBase {
       $options['limit'] = 0;
 
       // Count API call.
-      $call = $this->core->createCall($connector, $api_entity, $api_count_action, $parameters, $options);
+      $call = $this->core->createCall($connector, $api_entity, $api_count_action, $parameters, $options, NULL, $api_version);
       $this->core->executeCall($call);
       if ($call->getStatus() == Call::STATUS_DONE) {
         $result = $call->getReply();
@@ -261,7 +262,7 @@ class API extends QueryPluginBase {
       );
 
       // Data API call.
-      $call = $this->core->createCall($connector, $api_entity, $api_action, $parameters, $options);
+      $call = $this->core->createCall($connector, $api_entity, $api_action, $parameters, $options, NULL, $api_version);
       $this->core->executeCall($call);
       if ($call->getStatus() == Call::STATUS_DONE) {
         $result = $call->getReply();
@@ -317,7 +318,9 @@ class API extends QueryPluginBase {
             $referenced_dataset->entity,
             $referenced_dataset->action,
             $parameters,
-            $options
+            $options,
+            NULL,
+            $referenced_dataset->api_version
           );
           $this->core->executeCall($call);
           if ($call->getStatus() == Call::STATUS_DONE) {

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -189,7 +189,7 @@ class API4 extends QueryPluginBase {
       foreach ($view->field as $field) {
         if (!empty($table_data[$field->field]['cmrf_original_definition']['name'])) {
           $original_field_name = $table_data[$field->field]['cmrf_original_definition']['name'];
-          if (!in_array($original_field_name, $parameters['return'])) {
+          if (!in_array($original_field_name, $parameters['select'])) {
             $parameters['select'][] = $original_field_name;
           }
         }

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -36,9 +36,9 @@ class API4 extends QueryPluginBase {
   private array $fields = [];
 
   /**
-   * @phpstan-var array{field: string, orderby: 'ASC'|'DESC'}
+   * @phpstan-var array<array{field: string, orderby: 'ASC'|'DESC'}>
    */
-  private array $orderby = [];
+  public array $orderby = [];
 
   /**
    * @var \Drupal\cmrf_core\Core
@@ -473,7 +473,7 @@ class API4 extends QueryPluginBase {
   }
 
   /**
-   * PHPDoc copied from \Drupal\views\Plugin\views\query\Sql
+   * PHPDoc copied from \Drupal\views\Plugin\views\query\Sql.
    *
    * Add an ORDER BY clause to the query.
    *

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -1,4 +1,6 @@
-<?php namespace Drupal\cmrf_views\Plugin\views\query;
+<?php
+
+namespace Drupal\cmrf_views\Plugin\views\query;
 
 use Drupal;
 use Drupal\cmrf_core\Call;
@@ -138,7 +140,7 @@ class API4 extends QueryPluginBase {
    *
    * @access protected
    *
-   * @see \Drupal\cmrf_views\Plugin\views\query\API::addField()
+   * @see \Drupal\cmrf_views\Plugin\views\query\API4::addField()
    */
   protected function getFieldAlias($table_alias, $field) {
     $field = str_replace('.', '__', $field);
@@ -250,11 +252,6 @@ class API4 extends QueryPluginBase {
       // View result init.
       $view->result = [];
 
-      $field_id_alias_mapping = array_combine(
-        array_keys($view->field),
-        array_column($view->field, 'field_alias')
-      );
-
       // Data API call.
       $call = $this->core->createCall($connector, $api_entity, $api_action, $parameters, $options, NULL, $api_version);
       $this->core->executeCall($call);
@@ -286,7 +283,7 @@ class API4 extends QueryPluginBase {
       foreach ($view->relationship as $field_name => $relationship) {
         $field_name = self::getFieldAlias($view->storage->get('base_table'), $field_name);
         $referenced_keys = [];
-        foreach ($view->result as $row_key => &$row) {
+        foreach ($view->result as $row) {
           if (isset($row->{$field_name})) {
             $referenced_keys[] = $row->{$field_name};
           }
@@ -330,7 +327,7 @@ class API4 extends QueryPluginBase {
                   }
                 }
                 // Add values to corresponding base rows.
-                foreach ($view->result as $row_key => &$row) {
+                foreach ($view->result as &$row) {
                   if (
                     isset($row->{$field_name})
                     && $row->{$field_name} == $relationship_result[$base_field_alias]

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -295,6 +295,8 @@ class API4 extends QueryPluginBase {
       }
 
       // TODO: Adjust relationships for APIv4.
+      //       This might use a different approach now that JOINs are possible
+      //       with APIv4.
       foreach ($view->relationship as $field_name => $relationship) {
         $field_name = self::getFieldAlias($view->storage->get('base_table'), $field_name);
         $referenced_keys = [];

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -36,7 +36,7 @@ class API4 extends QueryPluginBase {
   private array $fields = [];
 
   /**
-   * @phpstan-var array<array{field: string, orderby: 'ASC'|'DESC'}>
+   * @phpstan-var array<array{field: string, orderby: 'ASC'|'DESC', api: bool}>
    */
   public array $orderby = [];
 
@@ -232,7 +232,9 @@ class API4 extends QueryPluginBase {
       // Do sorting
       if ([] !== $this->orderby) {
         foreach ($this->orderby as $orderby) {
-          $parameters['orderBy'][$orderby['field']] = $orderby['direction'];
+          if ($orderby['api']) {
+            $parameters['orderBy'][$orderby['field']] = $orderby['direction'];
+          }
         }
       }
 
@@ -502,17 +504,16 @@ class API4 extends QueryPluginBase {
     string $alias = '',
     array $params = []
   ): void {
-    if (NULL === $field) {
-      $field = $this->getFieldByAlias($alias);
-      if (NULL === $field) {
-        // @todo is this a valid state or should we throw an exception?
-        return;
-      }
+    if ($table != 'rand') {
+      // The CiviCRM API requires the original field name.
+      $alias = $field ?: $this->getFieldByAlias($alias);
     }
 
     $this->orderby[] = [
-      'field' => $field,
+      'field' => $alias,
       'direction' => strtoupper($order),
+      // Whether to send the sort field to the CiviCRM API.
+      'api' => $table != 'rand',
     ];
   }
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         "source": "https://github.com/CiviMRF/cmrf_core"
     },
     "require": {
-        "civimrf/cmrf_abstract_core": "^0.9"
+        "civimrf/cmrf_abstract_core": "^0.10"
     }
 }

--- a/config/install/cmrf_core.cmrf_profile.default.yml
+++ b/config/install/cmrf_core.cmrf_profile.default.yml
@@ -1,6 +1,7 @@
 dependencies: {  }
 id: default
 label: default
-url: 'http://path/to/civicrm'
+url: 'https://example.org/civicrm/ajax/rest'
+urlV4: 'https://example.org/civicrm/ajax/api4'
 site_key: SITE_KEY
 api_key: API_KEY

--- a/config/schema/cmrf_profile.schema.yml
+++ b/config/schema/cmrf_profile.schema.yml
@@ -12,7 +12,10 @@ cmrf_core.cmrf_profile.*:
       type: string
     url:
       type: string
-      label: 'URL'
+      label: 'URL APIv3'
+    urlV4:
+      type: string
+      label: 'URL APIv4'
     site_key:
       type: string
       label: 'Site key'

--- a/src/CMRFProfileListBuilder.php
+++ b/src/CMRFProfileListBuilder.php
@@ -15,7 +15,8 @@ class CMRFProfileListBuilder extends ConfigEntityListBuilder {
   public function buildHeader() {
     $header['label'] = $this->t('CiviMRF Profile');
     $header['id']    = $this->t('Machine name');
-    $header['url']   = $this->t('URL');
+    $header['url']   = $this->t('URL APIv3');
+    $header['urlV4'] = $this->t('URL APIv4');
     return $header + parent::buildHeader();
   }
 
@@ -27,6 +28,7 @@ class CMRFProfileListBuilder extends ConfigEntityListBuilder {
     $row['label'] = $entity->label();
     $row['id']    = $entity->id();
     $row['url']   = $entity->url;
+    $row['urlV4'] = $entity->urlV4;
     return $row + parent::buildRow($entity);
   }
 

--- a/src/Call.php
+++ b/src/Call.php
@@ -106,6 +106,8 @@ class Call extends AbstractCall {
     if (!empty($record->cached_until)) {
       $call->cached_until = new \DateTime($record->cached_until);
     }
+    $call->request_entity = $record->entity ?? $record->request['entity'];
+    $call->request_action = $record->action ?? $record->request['action'];
     $call->request = json_decode($record->request, TRUE);
     if (!isset($call->request['version'])) {
       // For backward compatibility.

--- a/src/Call.php
+++ b/src/Call.php
@@ -7,6 +7,10 @@ use CMRF\Core\Call as CallInterface;
 
 class Call extends AbstractCall {
 
+  protected string $request_entity;
+
+  protected string $request_action;
+
   protected array $request;
 
   protected ?array $reply = NULL;
@@ -76,16 +80,18 @@ class Call extends AbstractCall {
     // compile request
     if ('3' === $api_version) {
       $call->request = $call->compileRequest($parameters, $options);
+      $call->request['entity']     = $entity;
+      $call->request['action']     = $action;
     }
     else {
       $call->request = $parameters;
     }
-    $call->request['entity']     = $entity;
-    $call->request['action']     = $action;
+    $call->request_entity        = $entity;
+    $call->request_action        = $action;
     $call->request['version']    = $api_version;
     $call->status                = CallInterface::STATUS_INIT;
     $call->metadata['callbacks'] = $callbacks;
-    $call->callbacks = $callbacks;
+    $call->callbacks             = $callbacks;
 
     $call->initOptions($options);
 
@@ -135,11 +141,11 @@ class Call extends AbstractCall {
   }
 
   public function getEntity() {
-    return $this->request['entity'];
+    return $this->request_entity;
   }
 
   public function getAction() {
-    return $this->request['action'];
+    return $this->request_action;
   }
 
   public function getParameters() {

--- a/src/Call.php
+++ b/src/Call.php
@@ -84,7 +84,7 @@ class Call extends AbstractCall {
       $call->request['action']     = $action;
     }
     elseif ('4' === $api_version) {
-      $call->request = $call->compileRequestApi4($parameters, $options);
+      $call->request = $parameters;
     }
     $call->request_entity        = $entity;
     $call->request_action        = $action;

--- a/src/Call.php
+++ b/src/Call.php
@@ -83,8 +83,8 @@ class Call extends AbstractCall {
       $call->request['entity']     = $entity;
       $call->request['action']     = $action;
     }
-    else {
-      $call->request = $parameters;
+    elseif ('4' === $api_version) {
+      $call->request = $call->compileRequestApi4($parameters, $options);
     }
     $call->request_entity        = $entity;
     $call->request_action        = $action;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,9 +1,9 @@
 <?php namespace Drupal\cmrf_core;
 
-use CMRF\Connection\Curl as AbstractCurl;
+use CMRF\Connection\Curl;
 use CMRF\Core\Call;
 
-class Connection extends AbstractCurl {
+class Connection extends Curl {
 
   public function queueCall(Call $call) {
     // We don't have to do anything here.

--- a/src/Core.php
+++ b/src/Core.php
@@ -44,6 +44,7 @@ class Core extends AbstractCore {
       $return[$entity->id()] = [
         'label'    => $entity->label(),
         'url'      => $entity->url,
+        'urlV4'    => $entity->urlV4,
         'api_key'  => $entity->api_key,
         'site_key' => $entity->site_key,
         'cache_expire_days' => $entity->cache_expire_days,
@@ -56,6 +57,7 @@ class Core extends AbstractCore {
     $entity = CMRFProfile::load('default');
     return [
       'url'      => $entity->url,
+      'urlV4'    => $entity->urlV4,
       'api_key'  => $entity->api_key,
       'site_key' => $entity->site_key,
     ];

--- a/src/Entity/CMRFProfile.php
+++ b/src/Entity/CMRFProfile.php
@@ -31,6 +31,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "id",
  *     "label",
  *     "url",
+ *     "urlV4",
  *     "site_key",
  *     "api_key",
  *     "cache_expire_days",
@@ -63,11 +64,18 @@ class CMRFProfile extends ConfigEntityBase implements CMRFProfileInterface {
   protected $label;
 
   /**
-   * The URL of the CiviCRM installation
+   * The URL of the CiviCRM APIv3 endpoint.
    *
    * @var string
    */
   public $url;
+
+  /**
+   * The URL of the CiviCRM APIv4 endpoint.
+   *
+   * @var string
+   */
+  public ?string $urlV4;
 
   /**
    * The site key for the CiviCRM installation

--- a/src/Form/CMRFProfileForm.php
+++ b/src/Form/CMRFProfileForm.php
@@ -38,9 +38,17 @@ class CMRFProfileForm extends EntityForm {
 
     $form['url'] = [
       '#type'          => 'url',
-      '#title'         => $this->t('URL'),
+      '#title'         => $this->t('URL APIv3'),
       '#default_value' => $cmrf_profile->url,
-      '#description'   => $this->t('The URL to your CiviCRM installation e.g. https://civi.my.site/sites/all/modules/civicrm/extern/rest.php.'),
+      '#description'   => $this->t('The URL to your CiviCRM APIv3 endpoint e.g. https://example.org/civicrm/ajax/rest'),
+      '#required'      => TRUE,
+    ];
+
+    $form['urlV4'] = [
+      '#type'          => 'url',
+      '#title'         => $this->t('URL APIv4'),
+      '#default_value' => $cmrf_profile->urlV4,
+      '#description'   => $this->t('The URL to your CiviCRM APIv4 endpoint e.g. https://example.org/civicrm/ajax/api4'),
       '#required'      => TRUE,
     ];
 


### PR DESCRIPTION
With CiviMRF/CMRF_Abstract_Core#18, this introduces support for CiviCRM APIv4 and partly resolves #57 (leaving out the *Webform* integration for now).

This will be backwards-compatible so that it can be released within the `2.x` major version branch.

- Adds `entity` and `action` columns to the `civicrm_api_call` table (via the adapted schema provided by CiviMRF/CMRF_Abstract_Core) via a `hook_update_N()` implementation
- Adjusts the call report view and single displays according to the above schema change (in the provided optional config, but does not update it)
- Extends the `CMRFDataset` configuration entity with an `api_version` property, which is configurable per *CiviMRF Views Dataset*
- Adjusts `getfields` calls for the new structure those calls return with APIv4 in the `CMRFViews` controller
- Adds an `API4` (`civicrm_api4`) *Views* query plugin for APIv4 Datasets
- Extends the `CMRFProfile` configuration entity with an `urlV4` property, which is configurable per *CiviMRF Profile*
- Does some refactoring of the `Call` implementation