### PR TITLE
Send boolean in boolean filter for APIv4

### DIFF
--- a/cmrf_views/src/Plugin/views/filter/Boolean.php
+++ b/cmrf_views/src/Plugin/views/filter/Boolean.php
@@ -1,5 +1,6 @@
 <?php namespace Drupal\cmrf_views\Plugin\views\filter;
 
+use Drupal\cmrf_views\Plugin\views\query\API;
 use Drupal\views\Plugin\views\filter\BooleanOperator;
 
 /**
@@ -16,11 +17,15 @@ class Boolean extends BooleanOperator {
    */
   public function query() {
     $this->ensureMyTable();
-    $field = $this->realField;
-    $info = $this->operators();
-    if (!empty($info[$this->operator]['method'])) {
-      call_user_func([$this, $info[$this->operator]['method']], $field, $info[$this->operator]['query_operator']);
+    if ($this->isApiv3()) {
+      $this->query->addWhere($this->options['group'], $this->realField, (int) $this->value, $this->operator);
+    } else {
+      $this->query->addWhere($this->options['group'], $this->realField, (bool) $this->value, $this->operator);
     }
+  }
+
+  private function isApiv3(): bool {
+    return $this->query instanceof API;
   }
 
 }

--- a/cmrf_views/src/Plugin/views/filter/Boolean.php
+++ b/cmrf_views/src/Plugin/views/filter/Boolean.php
@@ -4,7 +4,7 @@ use Drupal\cmrf_views\Plugin\views\query\API;
 use Drupal\views\Plugin\views\filter\BooleanOperator;
 
 /**
- * Filter to handle dates stored as a timestamp.
+ * Filter to handle boolean values.
  *
  * @ingroup crmf_views_filter_handlers
  *


### PR DESCRIPTION
Previously integers (`0` or `1`) where send as query value independent of the API version. While integers work in case of DAO entities, `\Civi\Api4\Generic\Traits\ArrayQueryActionTrait::filterArray()` does not work with integers when comparing to booleans. (The result is always empty.)
https://github.com/civicrm/civicrm-core/blob/637387864718fbd11a1fe7e39431bb31e323116f/Civi/Api4/Generic/Traits/ArrayQueryActionTrait.php#L57