### PR TITLE
Use plain_text as text format in call log view, as this is guaranteed to exist

### DIFF
--- a/cmrf_call_report/config/optional/views.view.cmrf_calls.yml
+++ b/cmrf_call_report/config/optional/views.view.cmrf_calls.yml
@@ -776,7 +776,7 @@ display:
           tokenize: false
           content:
             value: 'Each CiviCRM Api Call is logged. Use this rapport for monitoring and debugging.'
-            format: basic_html
+            format: plain_text
           plugin_id: text
       footer: {  }
       empty: {  }


### PR DESCRIPTION
The CiviMRF Call Log view leads to errors of `Missing text format: basic_html.` on environments where this format does not exist. The view should use `plain_text` instead, as this is always available and the text does not contain any HTML.