### PR TITLE
Throw exception for unregistered profile

### DIFF
--- a/cmrf_call_report/cmrf_call_report.info.yml
+++ b/cmrf_call_report/cmrf_call_report.info.yml
@@ -6,4 +6,3 @@ core_version_requirement: ^8 || ^9 || ^10 || ^11
 package: CiviCRM
 dependencies:
   - cmrf_core
-  - cmrf_views

--- a/cmrf_call_report/cmrf_call_report.views.inc
+++ b/cmrf_call_report/cmrf_call_report.views.inc
@@ -35,9 +35,25 @@ function cmrf_call_report_views_data() {
       'id' => 'standard',
     ],
   ];
+  $data['civicrm_api_call']['duration'] = [
+    'title' => t('Duration (ms)'),
+    'help' => t('Duration of the call'),
+    'field' => [
+      'id' => 'standard',
+    ],
+    'argument' => [
+      'id' => 'numeric',
+    ],
+    'filter' => [
+      'id' => 'cmrf_call_report_duration',
+    ],
+    'sort' => [
+      'id' => 'standard',
+    ],
+  ];
   $data['civicrm_api_call']['status'] = [
     'title' => t('Status'),
-    'help' => t('Status van de request'),
+    'help' => t('Status of the request'),
     'field' => [
       'id' => 'standard',
     ],

--- a/cmrf_call_report/config/optional/views.view.cmrf_calls.yml
+++ b/cmrf_call_report/config/optional/views.view.cmrf_calls.yml
@@ -1,11 +1,10 @@
-langcode: en
+langcode: en-gb
 status: true
 dependencies:
   config:
     - system.menu.admin
   module:
     - cmrf_call_report
-    - cmrf_views
     - user
 id: cmrf_calls
 label: 'CiviCRM Api Calls'
@@ -16,156 +15,11 @@ base_table: civicrm_api_call
 base_field: cid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access site reports'
-      cache:
-        type: none
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 40
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            cid: cid
-            create_date: create_date
-            status: status
-            connector_id: connector_id
-            entity: entity
-            action: action
-            request: request
-            reply: reply
-            scheduled_date: scheduled_date
-            retry_count: retry_count
-          info:
-            cid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            create_date:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            connector_id:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            entity:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            action:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            request:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            reply:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            scheduled_date:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            retry_count:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
       fields:
         cid:
           id: cid
@@ -174,6 +28,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: standard
           label: ''
           exclude: true
           alter:
@@ -215,9 +72,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: null
-          entity_field: null
-          plugin_id: standard
         create_date:
           id: create_date
           table: civicrm_api_call
@@ -225,6 +79,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: Created
           exclude: false
           alter:
@@ -269,7 +124,6 @@ display:
           date_format: fallback
           custom_date_format: ''
           timezone: ''
-          plugin_id: standard
         status:
           id: status
           table: civicrm_api_call
@@ -277,6 +131,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: Status
           exclude: false
           alter:
@@ -318,7 +173,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         connector_id:
           id: connector_id
           table: civicrm_api_call
@@ -326,6 +180,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: 'Connector ID'
           exclude: false
           alter:
@@ -367,56 +222,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
-        entity:
-          id: entity
-          table: civicrm_api_call
-          field: entity
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: standard
-          label: Entity
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: pre
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
         action:
           id: action
           table: civicrm_api_call
@@ -425,7 +230,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: standard
-          label: Aktion
+          label: Action
           exclude: false
           alter:
             alter_text: false
@@ -454,7 +259,7 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: pre
+          element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
@@ -466,6 +271,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+        entity:
+          id: entity
+          table: civicrm_api_call
+          field: entity
+          plugin_id: standard
         request:
           id: request
           table: civicrm_api_call
@@ -473,6 +283,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: Request
           exclude: false
           alter:
@@ -502,7 +313,7 @@ display:
             trim: true
             preserve_tags: ''
             html: false
-          element_type: pre
+          element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
@@ -514,7 +325,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         reply:
           id: reply
           table: civicrm_api_call
@@ -522,6 +332,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: Reply
           exclude: false
           alter:
@@ -551,7 +362,7 @@ display:
             trim: true
             preserve_tags: ''
             html: false
-          element_type: pre
+          element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
@@ -563,7 +374,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         scheduled_date:
           id: scheduled_date
           table: civicrm_api_call
@@ -571,6 +381,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: cmrf_views_date
           label: Scheduled
           exclude: false
           alter:
@@ -615,7 +426,6 @@ display:
           date_format: fallback
           custom_date_format: ''
           timezone: ''
-          plugin_id: cmrf_views_date
         retry_count:
           id: retry_count
           table: civicrm_api_call
@@ -623,6 +433,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: 'Retry Count'
           exclude: false
           alter:
@@ -664,7 +475,106 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+        duration:
+          id: duration
+          table: civicrm_api_call
+          field: duration
+          relationship: none
+          group_type: group
+          admin_label: ''
           plugin_id: standard
+          label: 'Duration (ms)'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access site reports'
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts:
+        create_date:
+          id: create_date
+          table: civicrm_api_call
+          field: create_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: Created
+          exposed: false
+      arguments: {  }
       filters:
         status:
           id: status
@@ -673,6 +583,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: cmrf_call_report_status
           operator: in
           value: {  }
           group: 1
@@ -709,7 +620,6 @@ display:
               1: {  }
               2: {  }
               3: {  }
-          plugin_id: cmrf_call_report_status
         connector_id:
           id: connector_id
           table: civicrm_api_call
@@ -717,6 +627,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: cmrf_call_report_connectors
           operator: in
           value: {  }
           group: 1
@@ -750,20 +661,219 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: cmrf_call_report_connectors
-      sorts:
-        create_date:
-          id: create_date
+        action:
+          id: action
           table: civicrm_api_call
-          field: create_date
+          field: action
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
-          exposed: false
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
           expose:
-            label: Created
-          plugin_id: standard
+            operator_id: action_op
+            label: Action
+            description: ''
+            use_operator: false
+            operator: action_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: action
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              maker: '0'
+              beoordelaar: '0'
+              sta: '0'
+              administrator: '0'
+              crm: '0'
+              crmadministrator: '0'
+              ketest: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        entity:
+          id: entity
+          table: civicrm_api_call
+          field: entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: entity_op
+            label: Entity
+            description: ''
+            use_operator: false
+            operator: entity_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: entity
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              maker: '0'
+              beoordelaar: '0'
+              sta: '0'
+              administrator: '0'
+              crm: '0'
+              crmadministrator: '0'
+              ketest: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            cid: cid
+            create_date: create_date
+            status: status
+            connector_id: connector_id
+            action: action
+            entity: entity
+            request: request
+            reply: reply
+            scheduled_date: scheduled_date
+            retry_count: retry_count
+            duration: duration
+          default: '-1'
+          info:
+            cid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            create_date:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            connector_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            action:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            entity:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            request:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            reply:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            scheduled_date:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            retry_count:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            duration:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header:
         area:
           id: area
@@ -772,16 +882,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: true
-          tokenize: false
           content:
             value: 'Each CiviCRM Api Call is logged. Use this rapport for monitoring and debugging.'
-            format: plain_text
-          plugin_id: text
+            format: basic_html
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -792,9 +899,9 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -803,11 +910,11 @@ display:
         type: normal
         title: 'CiviMRF Calls'
         description: 'CiviMRF API Calls'
-        expanded: false
-        parent: system.admin_reports
         weight: 0
-        context: '0'
+        expanded: false
         menu_name: admin
+        parent: system.admin_reports
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/cmrf_call_report/src/Controller/CMRFCallreportController.php
+++ b/cmrf_call_report/src/Controller/CMRFCallreportController.php
@@ -58,6 +58,7 @@ class CMRFCallreportController extends ControllerBase {
       $request = json_encode($request, JSON_PRETTY_PRINT);
       $reply = json_encode(json_decode($call->reply,true), JSON_PRETTY_PRINT);
       $metadata = json_encode(json_decode($call->metadata,true), JSON_PRETTY_PRINT);
+      $duration = $call->duration;
       $scheduled_date = '';
       if (!empty($call->scheduled_date)) {
         $scheduled_date = new \DateTime($call->scheduled_date);
@@ -95,6 +96,10 @@ class CMRFCallreportController extends ControllerBase {
         [
           ['data' => t('Action'), 'header' => TRUE],
           ['data' => ['#markup' => '<pre>' . $action . '</pre>']],
+        ],
+        [
+          ['data' => t('Duration (ms)'), 'header' => TRUE],
+          ['data' => $duration],
         ],
         [
           ['data' => t('Request'), 'header' => TRUE],

--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -56,7 +56,7 @@ function cmrf_core_update_8202() {
  */
 function cmrf_core_update_8203(&$sandbox) {
   $durationField = array(
-    'type' => 'serial',
+    'type' => 'int',
     'unsigned' => TRUE,
     'not null' => TRUE,
     'description' => 'Call Duration',

--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -4,7 +4,7 @@ if (!class_exists('\CMRF\PersistenceLayer\SQLPersistingCallFactory')) {
   require_once dirname(__FILE__) . '/vendor/autoload.php';
 }
 
-use Drupal\cmrf_core\SQLPersistingCallFactory;
+use CMRF\PersistenceLayer\SQLPersistingCallFactory;
 use Drupal\cmrf_core\Entity\CMRFConnector;
 
 function cmrf_core_schema() {

--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -50,3 +50,17 @@ function cmrf_core_update_8202() {
     $connector->save();
   }
 }
+
+/**
+ * Add columns "duration" to the "civicrm_api_call" database table.
+ */
+function cmrf_core_update_8203(&$sandbox) {
+  $durationField = array(
+    'type' => 'serial',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'description' => 'Call Duration',
+    'default' => 0,
+  );
+  \Drupal::database()->schema()->addField('civicrm_api_call', 'duration', $durationField);
+}

--- a/cmrf_core.install
+++ b/cmrf_core.install
@@ -1,15 +1,15 @@
 <?php
 
-use Drupal\cmrf_core\CallFactory;
-use Drupal\cmrf_core\Entity\CMRFConnector;
-
 if (!class_exists('\CMRF\PersistenceLayer\SQLPersistingCallFactory')) {
   require_once dirname(__FILE__) . '/vendor/autoload.php';
 }
 
+use Drupal\cmrf_core\SQLPersistingCallFactory;
+use Drupal\cmrf_core\Entity\CMRFConnector;
+
 function cmrf_core_schema() {
   $array=array();
-  $array['civicrm_api_call'] = CallFactory::schema();
+  $array['civicrm_api_call'] = SQLPersistingCallFactory::schema();
   return $array;
 }
 

--- a/cmrf_views/src/Plugin/views/field/File.php
+++ b/cmrf_views/src/Plugin/views/field/File.php
@@ -1,14 +1,11 @@
 <?php namespace Drupal\cmrf_views\Plugin\views\field;
 
 use Drupal\cmrf_core\Core;
-use Drupal\Component\Utility\Crypt;
 use Drupal\Core\File\Exception\FileException;
 use Drupal\Core\File\Exception\InvalidStreamWrapperException;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Site\Settings;
-use Drupal\Core\Url;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
@@ -62,6 +59,7 @@ class File extends FieldPluginBase {
     $options['image_path']         = ['default' => 'civicrm'];
     $options['image_class']        = ['default' => NULL];
     $options['image_fallback_url'] = ['default' => NULL];
+    $options['obfuscate_file_path'] = ['default' => FALSE];
 
     return $options;
   }
@@ -136,6 +134,16 @@ class File extends FieldPluginBase {
         ],
       ],
       '#default_value' => isset($this->options['image_fallback_url']) ? $this->options['image_fallback_url'] : NULL,
+    ];
+
+    $form['obfuscate_file_path'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Obfuscate file path'),
+      '#description'   => $this->t(
+        'If checked, attempt to obfuscate the path to saved files by placing them in subdirectories based on hashes of their URLs. ' .
+        'This should not be used as a replacement for proper security measures.'
+      ),
+      '#default_value' => !empty($this->options['obfuscate_file_path']),
     ];
 
     parent::buildOptionsForm($form, $form_state);
@@ -348,6 +356,14 @@ class File extends FieldPluginBase {
     $image_path = empty($this->options['image_path']) ? NULL : $this->options['image_path'];
     $uri_path   = 'public://' . $image_path;
     $real_path  = \Drupal::service('file_system')->realpath($uri_path);
+
+    // If obfuscation of file paths is enabled, place the file in a folder based on a hash of its URL
+    if ($this->options['obfuscate_file_path'] ?? FALSE) {
+      $file_url_hash = hash('sha256', $attachment['url']);
+      $uri_path .= '/' . $file_url_hash;
+      $real_path .= '/' . $file_url_hash;
+    }
+
     // Create destination if it doesn't exist.
     if (!file_exists($real_path)) {
       mkdir($real_path, 0755, TRUE);
@@ -359,6 +375,23 @@ class File extends FieldPluginBase {
     if (!empty($file['extension'])) {
       $ext = '.' . $file['extension'];
     }
+
+    // If the attachment URL is a civicrm file URL (/civicrm/file) with a file hash (fcs param) and no filename (filename params),
+    // pathinfo() could be retrieving an incorrect filename/extension because the file hash (fcs param) can contain periods.
+    // In this case, unset extension so it can be retrieved from the name instead.
+    if (strpos($attachment['url'], '/civicrm/file?') !== FALSE) {
+      $urlQueryString = parse_url($attachment['url'])['query'] ?? '';
+      $urlQueryParams = [];
+      parse_str($urlQueryString, $urlQueryParams);
+
+      if (
+        isset($urlQueryParams['fcs']) &&
+        !isset($urlQueryParams['filename'])
+      ) {
+        $ext = '';
+      }
+    }
+
     if (empty($ext) && isset($attachment['name'])) {
       $file = pathinfo($attachment['name']);
       if (!empty($file['extension'])) {

--- a/cmrf_views/src/Plugin/views/field/File.php
+++ b/cmrf_views/src/Plugin/views/field/File.php
@@ -236,9 +236,9 @@ class File extends FieldPluginBase {
               }
               if (is_array($file)) {
                 $attachment = [
-                  'url' => $result[$file_api_url_param],
-                  'id' => $result[$file_api_id_param],
-                  'name' => $result[$file_api_name_param],
+                  'url' => $file[$file_api_url_param],
+                  'id' => $value,
+                  'name' => $file[$file_api_name_param],
                 ];
               }
             }

--- a/cmrf_views/src/Plugin/views/field/OptionList.php
+++ b/cmrf_views/src/Plugin/views/field/OptionList.php
@@ -60,7 +60,10 @@ class OptionList extends Standard implements MultiItemsFieldHandlerInterface {
     $alias = isset($field) ? $this->aliases[$field] : $this->field_alias;
     $options = $this->definition['options'];
     $key = $values->{$alias};
-    if (key_exists($key, $options)) {
+    if (is_array($key)) {
+      $key = $key[0];
+    }
+    if (array_key_exists($key, $options)) {
       return $options[$key];
     }
     return $key;

--- a/cmrf_views/src/Plugin/views/filter/OptionList.php
+++ b/cmrf_views/src/Plugin/views/filter/OptionList.php
@@ -1,5 +1,6 @@
 <?php namespace Drupal\cmrf_views\Plugin\views\filter;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\Plugin\views\filter\InOperator;
 
 /**
@@ -10,8 +11,22 @@ use Drupal\views\Plugin\views\filter\InOperator;
  * @ViewsFilter("cmrf_views_filter_optionlist")
  */
 class OptionList extends InOperator {
+  /**
+   * Array cache for refreshed field data, indexed by dataset ID.
+   *
+   * Used to prevent having to fetch field data multiple times per request if
+   * multiple filters belonging to the same dataset bypass caching of field
+   * option values.
+   *
+   * @var array<string,mixed>
+   */
+  protected static $_refreshedDatasetFields = [];
 
   public function getValueOptions() {
+    if ($this->options['expose']['bypass_cache'] ?? FALSE) {
+      $this->refreshValueOptions();
+    }
+
     if (isset($this->valueOptions)) {
       return $this->valueOptions;
     } else {
@@ -43,4 +58,61 @@ class OptionList extends InOperator {
     $this->query->addWhere($this->options['group'], "$this->realField", array_values($this->value), $this->operator);
   }
 
+  public function defaultExposeOptions() {
+    parent::defaultExposeOptions();
+    $this->options['expose']['bypass_cache'] = FALSE;
+  }
+
+  public function buildExposeForm(&$form, FormStateInterface $form_state) {
+    parent::buildExposeForm($form, $form_state);
+
+    $form['expose']['bypass_cache'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Bypass cache'),
+      '#description' => $this->t(
+        'If checked, the available options will be refreshed each time the view is loaded. ' .
+        'This is useful if your filter options are dynamic. ' .
+        'It is not recommended to combine this with view caching, as it could lead to undesirable/unpredicable results.'
+      ),
+      '#default_value' => !empty($this->options['expose']['bypass_cache']),
+    ];
+  }
+
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    $options['expose']['contains']['bypass_cache'] = ['default' => FALSE];
+
+    return $options;
+  }
+
+  protected function refreshValueOptions():  void {
+    // Our dataset ID is the uid minus the prefix, which is the table this filter thinks it belongs to
+    $datasetId = preg_replace('/^cmrf_views_/', '', $this->table);
+    // Our field ID is the real field this filter belongs to
+    $fieldId = $this->realField;
+
+    // If fields have not been refreshed for this dataset, do that now
+    if (!($fields = self::$_refreshedDatasetFields[$datasetId] ?? null)) {
+      /** @var \Drupal\cmrf_views\CMRFViews $cmrfViews */
+      $cmrfViews = \Drupal::service('cmrf_views.views');
+
+      // Look up dataset for given dataset ID
+      $datasets = $cmrfViews->getDatasets();
+      if (!($dataset = $datasets[$datasetId] ?? null)) {
+        return;
+      }
+
+      // Look up fields for given dataset, bypassing cache
+      $fields = self::$_refreshedDatasetFields[$datasetId] = $cmrfViews->getFields($dataset);
+    }
+
+    if (!($field = $fields[$fieldId] ?? null)) {
+      return;
+    }
+
+    // Replace current filter's value options with refreshed filter options from CiviCRM
+    $filterOptions = $field['filter']['options'] ?? [];
+    $this->valueOptions = $filterOptions;
+  }
 }

--- a/cmrf_views/src/Plugin/views/query/API.php
+++ b/cmrf_views/src/Plugin/views/query/API.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\cmrf_views\Plugin\views\query;
 
+use Drupal;
 use Drupal\cmrf_core\Call;
 use Drupal\cmrf_core\Core;
 use Drupal\cmrf_views\CMRFViewsResultRow;
@@ -23,7 +24,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   help = @Translation("Query against the CiviCRM API.")
  * )
  */
-class API extends QueryPluginBase {
+class API extends QueryPluginBase
+{
 
   /**
    * @var \Drupal\cmrf_core\Core
@@ -97,7 +99,8 @@ class API extends QueryPluginBase {
    *
    * @return string
    */
-  public function ensureTable($table, $relationship = NULL) {
+  public function ensureTable($table, $relationship = NULL)
+  {
     return $table;
   }
 
@@ -111,7 +114,8 @@ class API extends QueryPluginBase {
    *
    * @return mixed
    */
-  public function addField($table, $field, $alias = '', $params = []) {
+  public function addField($table, $field, $alias = '', $params = [])
+  {
     // We check for this specifically because it gets a special alias.
     if ($table == $this->view->storage->get('base_table') && $field == $this->view->storage->get('base_field') && empty($alias)) {
       $alias = $this->view->storage->get('base_field');
@@ -126,10 +130,10 @@ class API extends QueryPluginBase {
 
     // Create a field info array.
     $field_info = [
-        'field' => $field,
-        'table' => $table,
-        'alias' => $alias,
-      ] + $params;
+      'field' => $field,
+      'table' => $table,
+      'alias' => $alias,
+    ] + $params;
 
     // Test to see if the field is actually the same or not. Due to
     // differing parameters changing the aggregation function, we need
@@ -157,7 +161,8 @@ class API extends QueryPluginBase {
    *
    * @see \Drupal\cmrf_views\Plugin\views\query\API::addField()
    */
-  protected function getFieldAlias($table_alias, $field) {
+  protected function getFieldAlias($table_alias, $field)
+  {
     $field = CMRFViewsFieldNameUtil::normalize($field);
     return isset($this->fieldAliases[$table_alias][$field]) ? $this->fieldAliases[$table_alias][$field] : FALSE;
   }
@@ -168,7 +173,8 @@ class API extends QueryPluginBase {
    * @param \Drupal\views\ViewExecutable $view
    *   The view which is executed.
    */
-  public function build(ViewExecutable $view) {
+  public function build(ViewExecutable $view)
+  {
     // Store the view in the object to be able to use it later.
     $this->view = $view;
 
@@ -176,6 +182,16 @@ class API extends QueryPluginBase {
 
     // Let the pager modify the query to add limits.
     $view->pager->query();
+  }
+
+  protected static function normaliseArray(&$array)
+  {
+    ksort($array);
+    foreach ($array as &$value) {
+      if (is_array($value)) {
+        self::normaliseArray($value);
+      }
+    }
   }
 
 
@@ -186,7 +202,10 @@ class API extends QueryPluginBase {
    * Values to set: $view->result, $view->total_rows, $view->execute_time,
    * $view->current_page.
    */
-  public function execute(ViewExecutable $view) {
+  public function execute(ViewExecutable $view)
+  {
+    static $_dataCache = [];
+
     $table_data = $this->viewsData->get($view->storage->get('base_table'));
     if (!empty($table_data)) {
       $api_entity       = $table_data['table']['base']['entity'];
@@ -201,17 +220,6 @@ class API extends QueryPluginBase {
 
       $parameters = [];
       $start      = microtime(TRUE);
-
-      // Set the return fields
-      $parameters['return'] = [];
-      foreach ($view->field as $field) {
-        if (!empty($table_data[$field->field]['cmrf_original_definition']['name'])) {
-          $original_field_name = $table_data[$field->field]['cmrf_original_definition']['name'];
-          if (!in_array($original_field_name, $parameters['return'])) {
-            $parameters['return'][] = $original_field_name;
-          }
-        }
-      }
 
       // Set the query parameters.
       if (!empty($this->where)) {
@@ -269,20 +277,6 @@ class API extends QueryPluginBase {
       $options['cache'] = empty($view->query->options['cache']) ? NULL : $view->query->options['cache'];
       $options['limit'] = 0;
 
-      // Count API call.
-      $call = $this->core->createCall($connector, $api_entity, $api_count_action, $parameters, $options, NULL, $api_version);
-      $this->core->executeCall($call);
-      if ($call->getStatus() == Call::STATUS_DONE) {
-        $result = $call->getReply();
-        if (!empty($result['result'])) {
-          $view->getPager()->total_items = $result['result'];
-          $view->total_rows              = $result['result'];
-        }
-      }
-
-      // Update pager.
-      $view->getPager()->updatePageInfo();
-
       // TODO: verify views cache.
       $options['limit']  = $view->getPager()->getItemsPerPage();
       $options['offset'] = $view->getCurrentPage() * $view->getPager()->getItemsPerPage();
@@ -290,37 +284,61 @@ class API extends QueryPluginBase {
       // View result init.
       $view->result = [];
 
-      // Data API call.
-      $call = $this->core->createCall($connector, $api_entity, $api_action, $parameters, $options, NULL, $api_version);
-      $this->core->executeCall($call);
-      if ($call->getStatus() == Call::STATUS_DONE) {
-        $result = $call->getReply();
-        if ((!empty($result['values'])) && (is_array($result['values']))) {
-          $index = 0;
-          foreach ($result['values'] as $row) {
-            // Mandatory field for views rows.
-            $row['index'] = $index++;
-            // Add row to view result.
-            $base_result = [];
-            foreach ($row as $key => $value) {
-              if ($field_alias = self::getFieldAlias($view->storage->get('base_table'), $key)) {
-                // Explicit conversion of "" (empty) values to null values to prevent type errors when rendering of numeric values.
-                $value = !empty($value) ? $value : null;
-                if($view->field[$key]->pluginId=='numeric' && is_string($value)){
-                  $value = floatval($value);
-                }
-                $base_result[$field_alias] = $value;
-              }
+      $request = [$api_entity, $api_action, $parameters];
+      self::normaliseArray($request);
+      $hash = sha1(json_encode($request));
+      $result = [];
+      if (!isset($_dataCache[$hash])) {
+        // Data API call.
+        $call = $this->core->createCall($connector, $api_entity, $api_action, $parameters, $options, NULL, $api_version);
+        $this->core->executeCall($call);
+        if ($call->getStatus() == Call::STATUS_DONE) {
+          $result = $call->getReply();
+          $_dataCache[$hash] = $result;
+        }
+      } else {
+        $result = $_dataCache[$hash];
+      }
+
+      if ((!empty($result['values'])) && (is_array($result['values']))) {
+        $index = 0;
+        foreach ($result['values'] as $row) {
+          // Mandatory field for views rows.
+          $row['index'] = $index++;
+          // Add row to view result.
+          $base_result = [];
+          foreach ($row as $key => $value) {
+            if ($field_alias = self::getFieldAlias($view->storage->get('base_table'), $key)) {
+              // Explicit conversion of "" (empty) values to null values to prevent type errors when rendering of numeric values.
+              $base_result[$field_alias] = !empty($value) ? $value : null;
             }
-            $view->result[] = new CMRFViewsResultRow($base_result);
           }
-          // Set row indices for template_preprocess_views_view_fields to be
-          // able to retrieve the values.
-          array_walk($view->result, function (ResultRow $row, $index) {
-            $row->index = $index;
-          });
+          $view->result[] = new CMRFViewsResultRow($base_result);
+        }
+        // Set row indices for template_preprocess_views_view_fields to be
+        // able to retrieve the values.
+        array_walk($view->result, function (ResultRow $row, $index) {
+          $row->index = $index;
+        });
+      }
+      if (!empty($result['countMatched'])) {
+        $view->getPager()->total_items = $result['countMatched'];
+        $view->total_rows              = $result['countMatched'];
+      } else {
+        // Count API call.
+        $call = $this->core->createCall($connector, $api_entity, $api_count_action, $parameters, $options, NULL, $api_version);
+        $this->core->executeCall($call);
+        if ($call->getStatus() == Call::STATUS_DONE) {
+          $result = $call->getReply();
+          if (!empty($result['result'])) {
+            $view->getPager()->total_items = $result['result'];
+            $view->total_rows              = $result['result'];
+          }
         }
       }
+
+      // Update pager.
+      $view->getPager()->updatePageInfo();
 
       foreach ($view->relationship as $field_name => $relationship) {
         $field_name = self::getFieldAlias($view->storage->get('base_table'), $field_name);
@@ -428,7 +446,8 @@ class API extends QueryPluginBase {
    * @see \Drupal\Core\Database\Query\ConditionInterface::condition()
    * @see \Drupal\Core\Database\Query\Condition
    */
-  public function addWhere($group, $field, $value = NULL, $operator = NULL) {
+  public function addWhere($group, $field, $value = NULL, $operator = NULL)
+  {
     // Ensure all variants of 0 are actually 0. Thus '', 0 and NULL are all
     // the default group.
     if (empty($group)) {
@@ -450,13 +469,13 @@ class API extends QueryPluginBase {
   /**
    * Generates a unique placeholder used in the API query.
    */
-  public function placeholder($base = 'views') {
+  public function placeholder($base = 'views')
+  {
     static $placeholders = [];
     if (!isset($placeholders[$base])) {
       $placeholders[$base] = 0;
       return ':' . $base;
-    }
-    else {
+    } else {
       return ':' . $base . ++$placeholders[$base];
     }
   }
@@ -480,7 +499,8 @@ class API extends QueryPluginBase {
    *
    * @see QueryConditionInterface::where()
    */
-  public function addWhereExpression($group, $snippet, $args = []) {
+  public function addWhereExpression($group, $snippet, $args = [])
+  {
     // Ensure all variants of 0 are actually 0. Thus '', 0 and NULL are all
     // the default group.
     if (empty($group)) {
@@ -518,7 +538,8 @@ class API extends QueryPluginBase {
    * @param $params
    *   Any params that should be passed through to the addField.
    */
-  public function addOrderBy($table, $field = NULL, $order = 'ASC', $alias = '', $params = []) {
+  public function addOrderBy($table, $field = NULL, $order = 'ASC', $alias = '', $params = [])
+  {
     // Only ensure the table if it's not the special random key.
     // @todo: Maybe it would make sense to just add an addOrderByRand or something similar.
     if ($table && $table != 'rand') {
@@ -529,8 +550,7 @@ class API extends QueryPluginBase {
     // otherwise we assume it is a formula.
     if (!$alias && $table) {
       $as = $table . '_' . $field;
-    }
-    else {
+    } else {
       $as = $alias;
     }
 
@@ -539,7 +559,7 @@ class API extends QueryPluginBase {
     }
 
     $this->orderby[] = [
-//      'field'     => $as, // We need the real field name for sorting via API.
+      //      'field'     => $as, // We need the real field name for sorting via API.
       'field' => $field,
       'direction' => strtoupper($order),
     ];
@@ -554,11 +574,11 @@ class API extends QueryPluginBase {
    * @return array
    *   The API parameters array with filters and sorts added.
    */
-  protected function calculateApiParameters($parameters) {
+  protected function calculateApiParameters($parameters)
+  {
     // TODO: Add filters and sorts as API parameters.
     //   This might become a generic helper method for preparing API parameters
     //   from a view's filters and sorts.
     return $parameters;
   }
-
 }

--- a/cmrf_views/src/Plugin/views/query/API.php
+++ b/cmrf_views/src/Plugin/views/query/API.php
@@ -36,6 +36,21 @@ class API extends QueryPluginBase {
   protected $viewsData;
 
   /**
+   * @var array
+   */
+  protected $fieldAliases = [];
+
+  /**
+   * @var array
+   */
+  protected $fields = [];
+
+  /**
+   * @var array
+   */
+  protected $where = [];
+
+  /**
    * API constructor.
    *
    * @param array                   $configuration
@@ -290,7 +305,11 @@ class API extends QueryPluginBase {
             foreach ($row as $key => $value) {
               if ($field_alias = self::getFieldAlias($view->storage->get('base_table'), $key)) {
                 // Explicit conversion of "" (empty) values to null values to prevent type errors when rendering of numeric values.
-                $base_result[$field_alias] = !empty($value) ? $value : null;
+                $value = !empty($value) ? $value : null;
+                if($view->field[$key]->pluginId=='numeric' && is_string($value)){
+                  $value = floatval($value);
+                }
+                $base_result[$field_alias] = $value;
               }
             }
             $view->result[] = new CMRFViewsResultRow($base_result);

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\cmrf_views\Plugin\views\query;
 
+use Drupal;
 use Drupal\cmrf_core\Call;
 use Drupal\cmrf_core\Core;
 use Drupal\cmrf_views\CMRFViewsResultRow;

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -230,11 +230,9 @@ class API4 extends QueryPluginBase {
       }
 
       // Do sorting
-      if ([] !== $this->orderby) {
-        foreach ($this->orderby as $orderby) {
-          if ($orderby['api']) {
-            $parameters['orderBy'][$orderby['field']] = $orderby['direction'];
-          }
+      foreach ($this->orderby as $orderby) {
+        if ($orderby['api']) {
+          $parameters['orderBy'][$orderby['field']] = $orderby['direction'];
         }
       }
 
@@ -506,7 +504,11 @@ class API4 extends QueryPluginBase {
   ): void {
     if ($table != 'rand') {
       // The CiviCRM API requires the original field name.
-      $alias = CMRFViewsFieldNameUtil::normalize($field) ?: $this->getFieldByAlias($alias);
+      $alias = '' === $alias ? $field : $this->getFieldByAlias($alias);
+      if (NULL === $alias) {
+        // Invalid alias. Should not happen.
+        return;
+      }
     }
 
     $this->orderby[] = [

--- a/cmrf_views/src/Plugin/views/query/API4.php
+++ b/cmrf_views/src/Plugin/views/query/API4.php
@@ -233,7 +233,8 @@ class API4 extends QueryPluginBase {
       // Do sorting
       foreach ($this->orderby as $orderby) {
         if ($orderby['api']) {
-          $parameters['orderBy'][$orderby['field']] = $orderby['direction'];
+          $original_field_name = $table_data[$orderby['field']]['cmrf_original_definition']['name'];
+          $parameters['orderBy'][$original_field_name] = $orderby['direction'];
         }
       }
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         "source": "https://github.com/CiviMRF/cmrf_core"
     },
     "require": {
-        "civimrf/cmrf_abstract_core": "0.10.6"
+        "civimrf/cmrf_abstract_core": "^0.10.6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         "source": "https://github.com/CiviMRF/cmrf_core"
     },
     "require": {
-        "civimrf/cmrf_abstract_core": "^0.10"
+        "civimrf/cmrf_abstract_core": "0.10.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         "source": "https://github.com/CiviMRF/cmrf_core"
     },
     "require": {
-        "civimrf/cmrf_abstract_core": "0.10.5"
+        "civimrf/cmrf_abstract_core": "0.10.6"
     }
 }

--- a/src/CallFactory.php
+++ b/src/CallFactory.php
@@ -3,9 +3,9 @@
 
 namespace Drupal\cmrf_core;
 
-use CMRF\PersistenceLayer\SQLPersistingCallFactory;
+use CMRF\PersistenceLayer\CallFactory as AbstractCallFactory;
 
-class CallFactory extends SQLPersistingCallFactory {
+class CallFactory extends AbstractCallFactory {
 
   /**
    * @var \Drupal\cmrf_core\Core;
@@ -14,12 +14,112 @@ class CallFactory extends SQLPersistingCallFactory {
 
   protected $table_name;
 
-  public function __construct($sql_connection, $table_name, $constructor, $loader) {
-    parent::__construct($sql_connection, $table_name, $constructor, $loader);
+  public function __construct(callable $constructor, callable $loader)
+  {
+    $this->table_name = trim(\Drupal::database()->prefixTables("{civicrm_api_call}"), '"');
+    parent::__construct($constructor, $loader);
+
+  }
+
+
+  public function createOrFetch($connector_id, $core, $entity, $action, $parameters, $options, $callback, string $api_version = '3') {
+    /** @var \CMRF\Core\Call $call */
+    $call = parent::createOrFetch($connector_id, $core, $entity, $action, $parameters, $options, $callback, $api_version);
+
+    /** @var \Drupal\Core\Database\Connection $connection */
+    $connection = \Drupal::service('database');
+    if (!empty($options['cache'])) {
+      $today = new \DateTime();
+      $today = $today->format('Y-m-d H:i:s');
+      $hash = $call->getHash();
+
+      $stmnt = $connection->query("SELECT * FROM `" . $this->table_name . "` WHERE `request_hash` = ? AND `connector_id` = ? AND `cached_until` = ?", array($hash, $connector_id, $today));
+      $dataset = $stmnt->fetchObject();
+      if ($dataset != NULL) {
+        return $this->call_load($connector_id, $core, $dataset);
+      }
+    }
+
+    $query = "INSERT INTO `{$this->table_name}` (`status`,`connector_id`,`entity`,`action`,`request`,`metadata`,`request_hash`,`create_date`,`scheduled_date`) VALUES (?,?,?,?,?,?,?,?,?)";
+    $status = $call->getStatus();
+    $connectorID=$call->getConnectorID();
+    $entity=$call->getEntity();
+    $action=$call->getAction();
+    $request=json_encode($call->getRequest());
+    $metadata=json_encode($call->getMetadata());
+    $hash=$call->getHash();
+    $date=date('Y-m-d H:i:s');
+    $scheduled_date = NULL;
+    if($call->getScheduledDate() != NULL) {
+      $scheduled_date=$call->getScheduledDate()->format('Y-m-d H:i:s');
+    }
+
+    $connection->query($query, [$status,$connectorID,$entity,$action,$request,$metadata,$hash,$date, $scheduled_date]);
+    $call->setID($connection->lastInsertId());
+
+    return $call;
+  }
+
+  public function update(\CMRF\Core\Call $call) {
+    $id=$call->getID();
+    if(empty($id)) {
+      throw new \Exception("Unpersisted call given out to update. This won't work.");
+    }
+    else {
+      /** @var \Drupal\Core\Database\Connection $connection */
+      $connection = \Drupal::service('database');
+      $cache_date=null;
+      if ($call->getCachedUntil()) {
+        $cache_date=$call->getCachedUntil()->format('Y-m-d H:i:s');
+      }
+      $status=$call->getStatus();
+      $reply=json_encode($call->getReply());
+      $reply_date = NULL;
+      if($call->getReplyDate() != NULL) {
+        $reply_date=$call->getReplyDate()->format('Y-m-d H:i:s');
+      }
+      $scheduled_date = NULL;
+      if($call->getScheduledDate() != NULL) {
+        $scheduled_date=$call->getScheduledDate()->format('Y-m-d H:i:s');
+      }
+      $retrycount=$call->getRetryCount();
+      $connection->query("UPDATE `{$this->table_name}` set `status`=?,`reply`=?,`reply_date`=?,`scheduled_date`=?,`cached_until`=?,`retry_count`=? where `cid`=?", [$status,$reply,$reply_date,$scheduled_date,$cache_date,$retrycount,$id]);
+    }
+
+  }
+
+  /**
+   * Returns the queued calls which are ready for processing.
+   *
+   * @return array
+   *   The array consists of the call ids
+   */
+  public function getQueuedCallIds() {
+    $call_ids = array();
+    $result = \Drupal::database()->query("
+      select cid from {$this->table_name}
+      where (status = 'INIT' OR status = 'RETRY')
+      and (DATE(scheduled_date) < NOW() or scheduled_date is NULL)
+      ORDER BY scheduled_date ASC");
+    if ($result) {
+      while ($dataset = $result->fetch_object()) {
+        $call_ids[] = $dataset->cid;
+      }
+    }
+    return $call_ids;
+  }
+
+  public function loadCall($call_id,$core) {
+    $stmt = \Drupal::database()->query("SELECT * FROM `".$this->table_name."` WHERE `cid` = ? LIMIT 1", [$call_id]);
+    $dataset=$stmt->fetchObject();
+    if($dataset != NULL) {
+      return $this->call_load($dataset->connector_id,$core,$dataset);
+    }
   }
 
   public function purgeCachedCalls() {
     parent::purgeCachedCalls();
+    \Drupal::database()->query("DELETE FROM `". $this->table_name . "` WHERE `status` = 'DONE' and (`cached_until` < NOW() OR `cached_until` is NULL)");
     foreach ($this->core->getConnectors() as $connector_id => $connector) {
       $profile = $this->core->getConnectionProfile($connector_id)??['cache_expire_days'=>0, 'cache_clear_failed_api_calls'=>''];
       if ($profile['cache_expire_days'] > 0) {

--- a/src/CallFactory.php
+++ b/src/CallFactory.php
@@ -40,7 +40,7 @@ class CallFactory extends AbstractCallFactory {
       }
     }
 
-    $query = "INSERT INTO `{$this->table_name}` (`status`,`connector_id`,`entity`,`action`,`request`,`metadata`,`request_hash`,`create_date`,`scheduled_date`) VALUES (?,?,?,?,?,?,?,?,?)";
+    $query = "INSERT INTO `{$this->table_name}` (`status`,`connector_id`,`entity`,`action`,`request`,`metadata`,`request_hash`,`create_date`,`scheduled_date`, `duration`) VALUES (?,?,?,?,?,?,?,?,?,?)";
     $status = $call->getStatus();
     $connectorID=$call->getConnectorID();
     $entity=$call->getEntity();
@@ -49,12 +49,13 @@ class CallFactory extends AbstractCallFactory {
     $metadata=json_encode($call->getMetadata());
     $hash=$call->getHash();
     $date=date('Y-m-d H:i:s');
+    $duration = $call->getDuration();
     $scheduled_date = NULL;
     if($call->getScheduledDate() != NULL) {
       $scheduled_date=$call->getScheduledDate()->format('Y-m-d H:i:s');
     }
 
-    $connection->query($query, [$status,$connectorID,$entity,$action,$request,$metadata,$hash,$date, $scheduled_date]);
+    $connection->query($query, [$status,$connectorID,$entity,$action,$request,$metadata,$hash,$date, $scheduled_date, $duration]);
     $call->setID($connection->lastInsertId());
 
     return $call;
@@ -83,7 +84,8 @@ class CallFactory extends AbstractCallFactory {
         $scheduled_date=$call->getScheduledDate()->format('Y-m-d H:i:s');
       }
       $retrycount=$call->getRetryCount();
-      $connection->query("UPDATE `{$this->table_name}` set `status`=?,`reply`=?,`reply_date`=?,`scheduled_date`=?,`cached_until`=?,`retry_count`=? where `cid`=?", [$status,$reply,$reply_date,$scheduled_date,$cache_date,$retrycount,$id]);
+      $duration = $call->getDuration();
+      $connection->query("UPDATE `{$this->table_name}` set `status`=?,`reply`=?,`reply_date`=?,`scheduled_date`=?,`cached_until`=?,`retry_count`=?, `duration`=? where `cid`=?", [$status,$reply,$reply_date,$scheduled_date,$cache_date,$retrycount,$duration,$id]);
     }
 
   }

--- a/src/CallFactory.php
+++ b/src/CallFactory.php
@@ -33,7 +33,7 @@ class CallFactory extends AbstractCallFactory {
       $today = $today->format('Y-m-d H:i:s');
       $hash = $call->getHash();
 
-      $stmnt = $connection->query("SELECT * FROM `" . $this->table_name . "` WHERE `request_hash` = ? AND `connector_id` = ? AND `cached_until` = ?", array($hash, $connector_id, $today));
+      $stmnt = $connection->query("SELECT * FROM `" . $this->table_name . "` WHERE `request_hash` = ? AND `connector_id` = ? AND `cached_until` >= ? ORDER BY `cid` ASC LIMIT 1", array($hash, $connector_id, $today));
       $dataset = $stmnt->fetchObject();
       if ($dataset != NULL) {
         return $this->call_load($connector_id, $core, $dataset);

--- a/src/Core.php
+++ b/src/Core.php
@@ -9,10 +9,7 @@ class Core extends AbstractCore {
   protected $connections = [];
 
   public function __construct() {
-    $db         = \Drupal::database()->getConnectionOptions();
-    $table_name = trim(\Drupal::database()->prefixTables("{civicrm_api_call}"), '"');
-    $conn       = new \mysqli($db['host'], $db['username'], $db['password'], $db['database'], empty($db['port']) ? NULL : $db['port']);
-    $factory    = new CallFactory($conn, $table_name, ['\Drupal\cmrf_core\Call', 'createNew'], ['\Drupal\cmrf_core\Call', 'createWithRecord']);
+    $factory    = new CallFactory(['\Drupal\cmrf_core\Call', 'createNew'], ['\Drupal\cmrf_core\Call', 'createWithRecord']);
     $factory->setCore($this);
     parent::__construct($factory);
   }

--- a/src/Core.php
+++ b/src/Core.php
@@ -30,11 +30,15 @@ class Core extends AbstractCore {
   }
 
   public function getConnectionProfile($connector_id) {
-    $entity = CMRFConnector::load($connector_id);
-    if ($entity == NULL) {
+    $connector = CMRFConnector::load($connector_id);
+    if (NULL === $connector) {
       throw new \Exception("Unregistered connector '$connector_id'.", 1);
     }
-    return $this->getConnectionProfiles()[$entity->profile] ?? NULL;
+    $profiles = $this->getConnectionProfiles();
+    if (!isset($profiles[$connector->profile])) {
+      throw new \Exception("Unregistered profile '{$connector->profile}'.", 1);
+    }
+    return $profiles[$connector->profile];
   }
 
 


### PR DESCRIPTION
Fixes #68.

When a CiviMRF profile does not exist but is selected within a CiviMRF connector, there will be PHP warnings (`Warning: Undefined array key "produktivumgebung" in Drupal\cmrf_core\Core->getConnectionProfile() (line 32 of modules/contrib/cmrf_core/src/Core.php).`). This throws an exception instead.