### PR TITLE
Install missing cmrf_views_dataset_relationship schema in update hook

### DIFF
--- a/cmrf_views/cmrf_views.install
+++ b/cmrf_views/cmrf_views.install
@@ -29,3 +29,12 @@ function cmrf_views_update_8002(&$sandbox) {
       return TRUE;
   });
 }
+
+/**
+ * Install configuration entity type "cmrf_dataset_relationship" schema.
+ */
+function cmrf_views_update_8003(&$sandbox) {
+  \Drupal::entityDefinitionUpdateManager()->installEntityType(
+    \Drupal::entityTypeManager()->getDefinition('cmrf_dataset_relationship')
+  );
+}


### PR DESCRIPTION
This should remove the error message appearing in the status report when the module was installed before 009ac31a84efd74a000459854a1ed2fea05c0647.

There is also a branch by @kainuk for removing this functionality altogether: https://github.com/CiviMRF/cmrf_core/tree/removerelationship - not sure this fixes what was causing you to remove it. I haven't used this functionality for a long time, but I remember this being usable at least. @kainuk would you have a look if we can merge this?